### PR TITLE
Refactor: API 응답 형식 표준화 #14

### DIFF
--- a/FreeMarket/src/main/java/com/freemarket/freemarket/global/auth/api/AuthController.java
+++ b/FreeMarket/src/main/java/com/freemarket/freemarket/global/auth/api/AuthController.java
@@ -2,6 +2,7 @@ package com.freemarket.freemarket.global.auth.api;
 
 import com.freemarket.freemarket.global.auth.api.dto.AuthDto;
 import com.freemarket.freemarket.global.auth.application.AuthService;
+import com.freemarket.freemarket.global.common.ResponseDTO;
 import com.freemarket.freemarket.global.security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -36,12 +37,13 @@ public class AuthController {
             @ApiResponse(responseCode = "409", description = "이미 사용 중인 이메일")
     })
     @PostMapping("/signup")
-    public ResponseEntity<String> signup(
+    public ResponseEntity<ResponseDTO<Void>> signup(
             @Parameter(description = "회원가입 정보", required = true)
             @Valid @RequestBody AuthDto.SignupRequest request) {
         log.info("회원가입 컨트롤러 호출: {}", request.email());
         authService.signup(request);
-        return ResponseEntity.status(HttpStatus.CREATED).body("회원가입이 완료되었습니다.");
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ResponseDTO.success(null, "회원가입이 완료되었습니다."));
     }
 
     @Operation(summary = "로그인", description = "이메일과 비밀번호를 입력받아 로그인하고 JWT 토큰을 발급합니다.")
@@ -51,12 +53,12 @@ public class AuthController {
             @ApiResponse(responseCode = "400", description = "잘못된 요청")
     })
     @PostMapping("/login")
-    public ResponseEntity<AuthDto.TokenResponse> login(
+    public ResponseEntity<ResponseDTO<AuthDto.TokenResponse>> login(
             @Parameter(description = "로그인 정보", required = true)
             @Valid @RequestBody AuthDto.LoginRequest request) {
         log.info("로그인 컨트롤러 호출: {}", request.email());
         AuthDto.TokenResponse tokenResponse = authService.login(request);
-        return ResponseEntity.ok(tokenResponse);
+        return ResponseEntity.ok(ResponseDTO.success(tokenResponse, "로그인에 성공했습니다."));
     }
 
     @Operation(summary = "토큰 갱신", description = "리프레시 토큰을 사용하여 액세스 토큰을 갱신합니다.")
@@ -66,12 +68,12 @@ public class AuthController {
             @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰")
     })
     @PostMapping("/refresh")
-    public ResponseEntity<AuthDto.TokenResponse> refreshToken(
+    public ResponseEntity<ResponseDTO<AuthDto.TokenResponse>> refreshToken(
             @Parameter(description = "리프레시 토큰", required = true)
             @Valid @RequestBody AuthDto.TokenRefreshRequest request) {
         log.info("토큰 갱신 컨트롤러 호출");
         AuthDto.TokenResponse tokenResponse = authService.refreshToken(request);
-        return ResponseEntity.ok(tokenResponse);
+        return ResponseEntity.ok(ResponseDTO.success(tokenResponse, "토큰이 갱신되었습니다."));
     }
 
     @Operation(summary = "로그아웃", description = "사용자의 인증 정보를 제거하고 리프레시 토큰을 무효화합니다.")
@@ -80,7 +82,7 @@ public class AuthController {
             @ApiResponse(responseCode = "401", description = "인증 필요")
     })
     @PostMapping("/logout")
-    public ResponseEntity<String> logout() {
+    public ResponseEntity<ResponseDTO<Void>> logout() {
         log.info("로그아웃 컨트롤러 호출");
         // SecurityContext에서 현재 인증된 사용자 정보 가져오기
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
@@ -88,6 +90,6 @@ public class AuthController {
             CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
             authService.logout(userDetails.getUserId());
         }
-        return ResponseEntity.ok("로그아웃 되었습니다.");
+        return ResponseEntity.ok(ResponseDTO.success(null, "로그아웃 되었습니다."));
     }
 }

--- a/FreeMarket/src/main/java/com/freemarket/freemarket/global/common/ResponseDTO.java
+++ b/FreeMarket/src/main/java/com/freemarket/freemarket/global/common/ResponseDTO.java
@@ -7,15 +7,15 @@ import java.time.LocalDateTime;
 
 @Getter
 @Builder
-public class ApiResponse<T> {
+public class ResponseDTO<T> {
     private final boolean success;
     private final int status;
     private final String message;
     private final T data;
     private final LocalDateTime timestamp;
 
-    public static <T> ApiResponse<T> success(T data) {
-        return ApiResponse.<T>builder()
+    public static <T> ResponseDTO<T> success(T data) {
+        return ResponseDTO.<T>builder()
                 .success(true)
                 .status(200)
                 .message("요청이 성공했습니다.")
@@ -23,8 +23,8 @@ public class ApiResponse<T> {
                 .timestamp(LocalDateTime.now())
                 .build();
     }
-    public static <T> ApiResponse<T> success(T data, String message) {
-        return ApiResponse.<T>builder()
+    public static <T> ResponseDTO<T> success(T data, String message) {
+        return ResponseDTO.<T>builder()
                 .success(true)
                 .status(200)
                 .message(message)
@@ -33,8 +33,8 @@ public class ApiResponse<T> {
                 .build();
     }
 
-    public static <T> ApiResponse<T> error(int status, String message) {
-        return ApiResponse.<T>builder()
+    public static <T> ResponseDTO<T> error(int status, String message) {
+        return ResponseDTO.<T>builder()
                 .success(false)
                 .status(status)
                 .message(message)
@@ -42,8 +42,8 @@ public class ApiResponse<T> {
                 .build();
     }
 
-    public static <T> ApiResponse<T> error(int status, String message, T data) {
-        return ApiResponse.<T>builder()
+    public static <T> ResponseDTO<T> error(int status, String message, T data) {
+        return ResponseDTO.<T>builder()
                 .success(false)
                 .status(status)
                 .message(message)

--- a/FreeMarket/src/main/java/com/freemarket/freemarket/global/exception/GlobalExceptionHandler.java
+++ b/FreeMarket/src/main/java/com/freemarket/freemarket/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,6 @@
 package com.freemarket.freemarket.global.exception;
 
-import com.freemarket.freemarket.global.common.ApiResponse;
+import com.freemarket.freemarket.global.common.ResponseDTO;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -21,7 +21,7 @@ public class GlobalExceptionHandler {
 
     // BaseException 처리
     @ExceptionHandler(BaseException.class)
-    public ResponseEntity<ApiResponse<ErrorResponse>> handleBaseException(BaseException e) {
+    public ResponseEntity<ResponseDTO<ErrorResponse>> handleBaseException(BaseException e) {
         log.error("BaseException: {}", e.getMessage(), e);
 
         ErrorResponse errorResponse = new ErrorResponse(
@@ -33,12 +33,12 @@ public class GlobalExceptionHandler {
         );
 
         return ResponseEntity.status(e.getStatus())
-                .body(ApiResponse.error(e.getStatus().value(), e.getMessage(), errorResponse));
+                .body(ResponseDTO.error(e.getStatus().value(), e.getMessage(), errorResponse));
     }
 
     // Spring Security 인증 예외 처리
     @ExceptionHandler(AuthenticationException.class)
-    public ResponseEntity<ApiResponse<ErrorResponse>> handleAuthenticationException(AuthenticationException e) {
+    public ResponseEntity<ResponseDTO<ErrorResponse>> handleAuthenticationException(AuthenticationException e) {
         log.error("AuthenticationException: {}", e.getMessage(), e);
 
         String message = "인증에 실패했습니다.";
@@ -55,12 +55,12 @@ public class GlobalExceptionHandler {
         );
 
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                .body(ApiResponse.error(HttpStatus.UNAUTHORIZED.value(), message, errorResponse));
+                .body(ResponseDTO.error(HttpStatus.UNAUTHORIZED.value(), message, errorResponse));
     }
 
     // 접근 거부 예외 처리
     @ExceptionHandler(AccessDeniedException.class)
-    public ResponseEntity<ApiResponse<ErrorResponse>> handleAccessDeniedException(AccessDeniedException e) {
+    public ResponseEntity<ResponseDTO<ErrorResponse>> handleAccessDeniedException(AccessDeniedException e) {
         log.error("AccessDeniedException: {}", e.getMessage(), e);
 
         ErrorResponse errorResponse = new ErrorResponse(
@@ -72,12 +72,12 @@ public class GlobalExceptionHandler {
         );
 
         return ResponseEntity.status(HttpStatus.FORBIDDEN)
-                .body(ApiResponse.error(HttpStatus.FORBIDDEN.value(), "접근 권한이 없습니다.", errorResponse));
+                .body(ResponseDTO.error(HttpStatus.FORBIDDEN.value(), "접근 권한이 없습니다.", errorResponse));
     }
 
     // 유효성 검증 예외 처리
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ApiResponse<ErrorResponse>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+    public ResponseEntity<ResponseDTO<ErrorResponse>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
         log.error("MethodArgumentNotValidException: {}", e.getMessage(), e);
 
         List<ErrorResponse.FieldError> fieldErrors = e.getFieldErrors().stream()
@@ -97,12 +97,12 @@ public class GlobalExceptionHandler {
         );
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ApiResponse.error(HttpStatus.BAD_REQUEST.value(), "입력값이 올바르지 않습니다.", errorResponse));
+                .body(ResponseDTO.error(HttpStatus.BAD_REQUEST.value(), "입력값이 올바르지 않습니다.", errorResponse));
     }
 
     // 바인딩 예외 처리
     @ExceptionHandler(BindException.class)
-    public ResponseEntity<ApiResponse<ErrorResponse>> handleBindException(BindException e) {
+    public ResponseEntity<ResponseDTO<ErrorResponse>> handleBindException(BindException e) {
         log.error("BindException: {}", e.getMessage(), e);
 
         List<ErrorResponse.FieldError> fieldErrors = e.getBindingResult().getFieldErrors().stream()
@@ -122,12 +122,12 @@ public class GlobalExceptionHandler {
         );
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ApiResponse.error(HttpStatus.BAD_REQUEST.value(), "입력값이 올바르지 않습니다.", errorResponse));
+                .body(ResponseDTO.error(HttpStatus.BAD_REQUEST.value(), "입력값이 올바르지 않습니다.", errorResponse));
     }
 
     // 그 외 모든 예외 처리
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ApiResponse<ErrorResponse>> handleException(Exception e) {
+    public ResponseEntity<ResponseDTO<ErrorResponse>> handleException(Exception e) {
         log.error("Unexpected Exception: {}", e.getMessage(), e);
 
         ErrorResponse errorResponse = new ErrorResponse(
@@ -139,7 +139,7 @@ public class GlobalExceptionHandler {
         );
 
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR.value(), "서버 내부 오류가 발생했습니다.", errorResponse));
+                .body(ResponseDTO.error(HttpStatus.INTERNAL_SERVER_ERROR.value(), "서버 내부 오류가 발생했습니다.", errorResponse));
     }
 
 }


### PR DESCRIPTION
현재 AuthController의 API 응답 형식이 엔드포인트마다 다르게 구현되어 있다. 
이로 인해 클라이언트에서 응답을 처리하는 로직이 일관되지 않고, API 문서화와 테스트가 복잡해질 수 있다.
 표준화된 응답 형식을 도입하여 전체 API에서 일관된 구조를 제공한다.


**현재 상태**

- /api/auth/signup: ResponseEntity<String> 반환
- /api/auth/login: ResponseEntity<AuthDto.TokenResponse> 반환
- /api/auth/refresh: ResponseEntity<AuthDto.TokenResponse> 반환
- /api/auth/logout: ResponseEntity<String> 반환

**변경 필요 사항**

- 모든 API 응답을 ApiResponse<T> 형식으로 표준화
- ErrorResponse 클래스를 record로 변경하여 불변성 보장
- ApiResponse<T> 클래스도 record로 구현하여 코드 일관성 유지
- GlobalExceptionHandler에서 표준화된 응답 형식 적용