### PR TITLE
Rename: config 클래스 패키지 위치 변경

### DIFF
--- a/FreeMarket/src/main/java/com/freemarket/freemarket/global/auth/config/EncoderConfig.java
+++ b/FreeMarket/src/main/java/com/freemarket/freemarket/global/auth/config/EncoderConfig.java
@@ -1,4 +1,4 @@
-package com.freemarket.freemarket.global.security;
+package com.freemarket.freemarket.global.auth.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/FreeMarket/src/main/java/com/freemarket/freemarket/global/auth/config/WebSecurityConfig.java
+++ b/FreeMarket/src/main/java/com/freemarket/freemarket/global/auth/config/WebSecurityConfig.java
@@ -1,4 +1,4 @@
-package com.freemarket.freemarket.global.security;
+package com.freemarket.freemarket.global.auth.config;
 
 import com.freemarket.freemarket.global.jwt.JwtFilter;
 import com.freemarket.freemarket.global.jwt.JwtProvider;


### PR DESCRIPTION
security 패키지 하위에 있는 config 클래스를 global 패키지 하위의 config 패키지로 이동시켰다.