### PR TITLE
Feat: 학교 이메일 인증 구현 #39

### DIFF
--- a/FreeMarket/src/main/java/com/freemarket/freemarket/global/auth/api/EmailVerificationController.java
+++ b/FreeMarket/src/main/java/com/freemarket/freemarket/global/auth/api/EmailVerificationController.java
@@ -1,0 +1,49 @@
+package com.freemarket.freemarket.global.auth.api;
+
+import com.freemarket.freemarket.global.auth.api.dto.EmailVerificationDto;
+import com.freemarket.freemarket.global.auth.application.EmailVerificationService;
+import com.freemarket.freemarket.global.common.ResponseDTO;
+import com.freemarket.freemarket.global.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.apache.coyote.BadRequestException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.parameters.P;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth/email-verification")
+@RequiredArgsConstructor
+@Tag(name = "Email Verification", description = "이메일 인증 API")
+public class EmailVerificationController {
+
+    private final EmailVerificationService emailVerificationService;
+
+    @PostMapping("/send")
+    @Operation(summary = "인증 이메일 발송", description = "학교 이메일로 인증 코드를 발송합니다.")
+    public ResponseEntity<ResponseDTO<EmailVerificationDto.EmailVerificationResponse>> sendVerificationEmail(
+            @Parameter(description = "이메일")
+            @Valid @RequestBody EmailVerificationDto.EmailVerificationRequest request) throws BadRequestException {
+
+        EmailVerificationDto.EmailVerificationResponse response = emailVerificationService.sendVerificationEmail(request);
+        return ResponseEntity.ok(ResponseDTO.success(response));
+    }
+
+    @PostMapping("/verify")
+    @Operation(summary = "인증 코드 확인", description = "발송된 인증 코드를 확인합니다.")
+    public ResponseEntity<ResponseDTO<EmailVerificationDto.EmailVerificationResponse>> verifyEmail(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Parameter(description = "이메일과 인증 코드 정보")
+            @Valid @RequestBody EmailVerificationDto.VerificationCodeRequest request) throws BadRequestException {
+
+        EmailVerificationDto.EmailVerificationResponse response = emailVerificationService.verifyEmail(userDetails.getEmail(), request);
+        return ResponseEntity.ok(ResponseDTO.success(response));
+    }
+}

--- a/FreeMarket/src/main/java/com/freemarket/freemarket/global/auth/api/dto/EmailVerificationDto.java
+++ b/FreeMarket/src/main/java/com/freemarket/freemarket/global/auth/api/dto/EmailVerificationDto.java
@@ -1,0 +1,30 @@
+package com.freemarket.freemarket.global.auth.api.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public class EmailVerificationDto {
+
+    // 이메일 인증 요청
+    public record EmailVerificationRequest(
+           @NotBlank(message = "이메일은 필수 입력값입니다.")
+           @Email(message = "이메일 형식이 올바르지 않습니다.")
+           String email
+    ) {}
+
+    // 이메일 인증 코드 확인 요청
+    public record VerificationCodeRequest(
+            @NotBlank(message = "이메일은 필수 입력값입니다.")
+            @Email(message = "이메일 형식이 올바르지 않습니다.")
+            String email,
+
+            @NotBlank(message = "인증 코드는 필수 입력값입니다.")
+            String verificationCode
+    ) {}
+
+    // 이메일 인증 응답
+    public record EmailVerificationResponse(
+            boolean success,
+            String message
+    ) {}
+}

--- a/FreeMarket/src/main/java/com/freemarket/freemarket/global/auth/application/EmailVerificationService.java
+++ b/FreeMarket/src/main/java/com/freemarket/freemarket/global/auth/application/EmailVerificationService.java
@@ -1,0 +1,116 @@
+package com.freemarket.freemarket.global.auth.application;
+
+import com.freemarket.freemarket.global.auth.api.dto.EmailVerificationDto;
+import com.freemarket.freemarket.global.auth.domain.email.EmailVerification;
+import com.freemarket.freemarket.global.auth.domain.email.EmailVerificationRepository;
+import com.freemarket.freemarket.user.domain.User;
+import com.freemarket.freemarket.user.domain.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.apache.coyote.BadRequestException;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.SecureRandom;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class EmailVerificationService {
+
+    private final EmailVerificationRepository emailVerificationRepository;
+    private final UserRepository userRepository;
+    private final JavaMailSender mailSender;
+
+    private static final String ALLOWED_DOMAINS = "office.skhu.ac.kr";
+    private static final int CODE_LENGTH = 6;
+    private static final int EXPIRY_MINUTES = 10;
+
+    @Transactional
+    public EmailVerificationDto.EmailVerificationResponse sendVerificationEmail(EmailVerificationDto.EmailVerificationRequest request) throws BadRequestException {
+        String email = request.email();
+
+        // 학교 이메일 도메인 확인
+        if (!isSchoolEmail(email)) {
+            throw new BadRequestException("학교 이메일만 사용할 수 있습니다.");
+        }
+
+        // 인증 코드 생성
+        String verificationCode = generateVerificationCode();
+
+        // 이전 인증 코드 만료 처리
+        emailVerificationRepository.findByEmail(email)
+                .ifPresent(emailVerificationRepository::delete);
+
+        // 새 인증 코드 저장
+        EmailVerification emailVerification = EmailVerification.builder()
+                .email(email)
+                .verificationCode(verificationCode)
+                .expiryDate(LocalDateTime.now().plusMinutes(EXPIRY_MINUTES))
+                .build();
+
+        emailVerificationRepository.save(emailVerification);
+
+        // 이메일 발송
+        sendEmail(email, "이메일 인증 코드", "인증 코드: " + verificationCode + "\n\n이 코드는 " + EXPIRY_MINUTES + "분 후에 만료됩니다.");
+
+        return new EmailVerificationDto.EmailVerificationResponse(true, "인증 이메일이 발송되었습니다.");
+    }
+
+    @Transactional
+    public EmailVerificationDto.EmailVerificationResponse verifyEmail(String userEmail, EmailVerificationDto.VerificationCodeRequest request) throws BadRequestException {
+        String email = request.email();
+        String code = request.verificationCode();
+
+        EmailVerification verification = emailVerificationRepository.findByEmail(email)
+                .orElseThrow(() -> new BadRequestException("인증 정보를 찾을 수 업습니다."));
+
+        if (verification.isExpired()) {
+            throw new BadRequestException("인증 코드가 만료되었습니다.");
+        }
+
+        if (!verification.getVerificationCode().equals(code)) {
+            throw new BadRequestException("인증 코드가 일치하지 않습니다.");
+        }
+
+        verification.verify();
+        emailVerificationRepository.save(verification);
+
+        // 사용자의 이메일 인증 상태 업데이트
+        Optional<User> userOpt = userRepository.findByEmail(userEmail);
+        if (userOpt.isPresent()) {
+            User user = userOpt.get();
+            user.changeEmailVerified(true);
+            userRepository.save(user);
+        }
+
+        return new EmailVerificationDto.EmailVerificationResponse(true, "이메일 인증이 완료되었습니다.");
+    }
+
+    private boolean isSchoolEmail(String email) {
+        return email.toLowerCase().endsWith("@" + ALLOWED_DOMAINS);
+    }
+
+    private String generateVerificationCode() {
+        SecureRandom random = new SecureRandom();
+        StringBuilder code = new StringBuilder();
+
+        for (int i = 0; i < CODE_LENGTH; i++) {
+            code.append(random.nextInt(10));
+        }
+
+        return code.toString();
+    }
+
+    private void sendEmail(String to, String subject, String text) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(to);
+        message.setSubject(subject);
+        message.setText(text);
+        mailSender.send(message);
+    }
+}

--- a/FreeMarket/src/main/java/com/freemarket/freemarket/global/auth/domain/email/EmailVerification.java
+++ b/FreeMarket/src/main/java/com/freemarket/freemarket/global/auth/domain/email/EmailVerification.java
@@ -1,0 +1,48 @@
+package com.freemarket.freemarket.global.auth.domain.email;
+
+import com.freemarket.freemarket.global.auditing.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "email_verification")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class EmailVerification extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String verificationCode;
+
+    @Column(nullable = false)
+    private LocalDateTime expiryDate;
+
+    @Column(nullable = false)
+    private boolean verified;
+
+    @Builder
+    public EmailVerification(String email, String verificationCode, LocalDateTime expiryDate, boolean verified) {
+        this.email = email;
+        this.verificationCode = verificationCode;
+        this.expiryDate = expiryDate;
+        this.verified = false;
+    }
+
+    public void verify() {
+        this.verified = true;
+    }
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(this.expiryDate);
+    }
+}

--- a/FreeMarket/src/main/java/com/freemarket/freemarket/global/auth/domain/email/EmailVerificationRepository.java
+++ b/FreeMarket/src/main/java/com/freemarket/freemarket/global/auth/domain/email/EmailVerificationRepository.java
@@ -1,0 +1,9 @@
+package com.freemarket.freemarket.global.auth.domain.email;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface EmailVerificationRepository extends JpaRepository<EmailVerification, Long> {
+    Optional<EmailVerification> findByEmail(String email);
+}

--- a/FreeMarket/src/main/java/com/freemarket/freemarket/product/api/ProductController.java
+++ b/FreeMarket/src/main/java/com/freemarket/freemarket/product/api/ProductController.java
@@ -16,6 +16,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.coyote.BadRequestException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -52,7 +53,7 @@ public class ProductController {
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
             @Parameter(description = "상품 등록 정보", required = true, content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
             @Valid @RequestPart("request") ProductDto.CreateRequest request,
-            @Parameter(description = "이미지 파일") @RequestPart(value = "images", required = false)List<MultipartFile> images) {
+            @Parameter(description = "이미지 파일") @RequestPart(value = "images", required = false)List<MultipartFile> images) throws BadRequestException {
 
 
         log.info("상품 등록 요청: 사용자 ID {}", userDetails.getUserId());

--- a/FreeMarket/src/main/java/com/freemarket/freemarket/product/application/ProductService.java
+++ b/FreeMarket/src/main/java/com/freemarket/freemarket/product/application/ProductService.java
@@ -8,6 +8,7 @@ import com.freemarket.freemarket.user.domain.UserRepository;
 import com.freemarket.freemarket.user.exception.UserException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.coyote.BadRequestException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -29,9 +30,12 @@ public class ProductService {
 
     // 상품 등록
     @Transactional
-    public ProductDto.ProductResponse createProduct(Long userId, ProductDto.CreateRequest request, List<MultipartFile> images) {
+    public ProductDto.ProductResponse createProduct(Long userId, ProductDto.CreateRequest request, List<MultipartFile> images) throws BadRequestException {
         User seller = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException.UserNotFoundException(userId));
+
+        // 학교 이메일 인증 여부 확인
+        emailVerification(seller);
 
         Product product = Product.builder()
                 .name(request.name())
@@ -202,11 +206,17 @@ public class ProductService {
 
         return product;
     }
-
+    
     private Product findProduct(Long productId) {
         Product product = productRepository.findById(productId)
                 .orElseThrow(() -> new RuntimeException("상품을 찾을 수 없습니다: " + productId));
         return product;
+    }
+
+    private static void emailVerification(User seller) throws BadRequestException {
+        if (!seller.isEmailVerified()) {
+            throw new BadRequestException("학교 이메일 인증이 필요합니다.");
+        }
     }
 
 }

--- a/FreeMarket/src/main/java/com/freemarket/freemarket/user/domain/User.java
+++ b/FreeMarket/src/main/java/com/freemarket/freemarket/user/domain/User.java
@@ -40,6 +40,9 @@ public class User extends BaseTimeEntity {
     private String provider;     // 예: "naver", "google", "kakao"
     private String providerId;   // 소셜 플랫폼에서 제공하는 고유 사용자 ID
 
+    @Column(nullable = false)
+    private boolean emailVerified = false;
+
     @Builder
     public User(String email, String password, String name, String phone, boolean enabled, UserRole role, String provider, String providerId) {
         this.email = email;
@@ -87,5 +90,10 @@ public class User extends BaseTimeEntity {
     public void updateProvider(String provider, String providerId) {
         this.provider = provider;
         this.providerId = providerId;
+    }
+
+    // 이메일 인증 상태 설정
+    public void changeEmailVerified(boolean emailVerified) {
+        this.emailVerified = emailVerified;
     }
 }


### PR DESCRIPTION
사용자가 거래 기능을 사용하기 전에 학교 이메일을 인증하는 기능을 구현한다. 이를 통해 실제 대학교 구성원만 거래에 참여할 수 있도록 하여 플랫폼의 신뢰성을 높인다.

## 요구사항
- 학교 이메일(@office.skhu.ac.kr) 도메인 검증
- 이메일 인증 코드 생성 및 발송
- 인증 코드 검증 기능 구현
- 인증된 사용자만 거래(상품 등록 등) 기능 사용 가능
- 인증 상태를 사용자 계정에 저장

## 구현 상세
- 이메일 인증 엔터티 생성
- 이메일, 인증 코드, 만료 시간, 인증 상태 필드 포함
- - 인증 코드 만료 시간은 10분으로 설정


## 이메일 인증 서비스 구현
- 6자리 숫자 인증 코드 생성
- JavaMailSender를 사용한 이메일 발송
- 인증 코드 검증 로직


## API 엔드포인트 구현
- 인증 이메일 발송 엔드포인트 (/api/auth/email-verification/send)
- 인증 코드 확인 엔드포인트 (/api/auth/email-verification/verify)


## User 엔티티 업데이트
- 이메일 인증 상태 필드 추가
- 인증 상태 변경 메서드 구현


## 상품 등록 제한 구현
- ProductService에서 상품 등록 시 이메일 인증 여부 확인
- 인증되지 않은 사용자의 상품 등록 요청 차단