### PR TITLE
Feat: DTO Swagger 문서화 #41

### DIFF
--- a/FreeMarket/src/main/java/com/freemarket/freemarket/global/auth/api/dto/AuthDto.java
+++ b/FreeMarket/src/main/java/com/freemarket/freemarket/global/auth/api/dto/AuthDto.java
@@ -1,5 +1,6 @@
 package com.freemarket.freemarket.global.auth.api.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
@@ -8,43 +9,61 @@ import lombok.Builder;
 
 public class AuthDto {
 
+    @Schema(description = "회원가입 요청")
     public record SignupRequest(
+            @Schema(description = "이메일 주소", example = "user@example.com")
             @NotBlank(message = "이메일은 필수 입력값입니다.")
             @Email(message = "이메일 형식이 올바르지 않습니다.")
             String email,
 
+            @Schema(description = "비밀번호 (최소 8자 이상)", example = "password123")
             @NotBlank(message = "비밀번호는 필수 입력값입니다.")
             @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
             String password,
 
+            @Schema(description = "사용자 이름", example = "홍길동")
             @NotBlank(message = "이름은 필수 입력값입니다.")
             String name,
 
+            @Schema(description = "휴대폰 번호", example = "010-1234-5678")
             @Pattern(regexp = "^01(?:0|1|[6-9])[.-]?(\\d{3}|\\d{4})[.-]?(\\d{4})$", message = "휴대폰 번호 형식이 올바르지 않습니다.")
             String phone
     ) {
     }
 
+    @Schema(description = "로그인 요청")
     public record LoginRequest(
+            @Schema(description = "이메일 주소", example = "user@example.com")
             @NotBlank(message = "이메일은 필수 입력값입니다.")
             @Email(message = "이메일 형식이 올바르지 않습니다.")
             String email,
 
+            @Schema(description = "비밀번호", example = "password123")
             @NotBlank(message = "비밀번호는 필수 입력값입니다.")
             String password
     ) {
     }
 
     @Builder
+    @Schema(description = "토큰 응답")
     public record TokenResponse(
+            @Schema(description = "JWT 액세스 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
             String accessToken,
+            
+            @Schema(description = "JWT 리프레시 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
             String refreshToken,
+            
+            @Schema(description = "토큰 타입", example = "Bearer")
             String tokenType,
+            
+            @Schema(description = "액세스 토큰 만료 시간(초)", example = "3600")
             Long expiresIn
     ) {
     }
 
+    @Schema(description = "토큰 갱신 요청")
     public record TokenRefreshRequest(
+            @Schema(description = "리프레시 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
             @NotBlank(message = "리프레시 토큰은 필수 입력값입니다.")
             String refreshToken
     ) {

--- a/FreeMarket/src/main/java/com/freemarket/freemarket/global/auth/api/dto/EmailVerificationDto.java
+++ b/FreeMarket/src/main/java/com/freemarket/freemarket/global/auth/api/dto/EmailVerificationDto.java
@@ -1,30 +1,37 @@
 package com.freemarket.freemarket.global.auth.api.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
 public class EmailVerificationDto {
 
-    // 이메일 인증 요청
+    @Schema(description = "이메일 인증 요청")
     public record EmailVerificationRequest(
+           @Schema(description = "학교 이메일 주소", example = "student@office.skhu.ac.kr")
            @NotBlank(message = "이메일은 필수 입력값입니다.")
            @Email(message = "이메일 형식이 올바르지 않습니다.")
            String email
     ) {}
 
-    // 이메일 인증 코드 확인 요청
+    @Schema(description = "이메일 인증 코드 확인 요청")
     public record VerificationCodeRequest(
+            @Schema(description = "학교 이메일 주소", example = "student@office.skhu.ac.kr")
             @NotBlank(message = "이메일은 필수 입력값입니다.")
             @Email(message = "이메일 형식이 올바르지 않습니다.")
             String email,
 
+            @Schema(description = "6자리 인증 코드", example = "123456")
             @NotBlank(message = "인증 코드는 필수 입력값입니다.")
             String verificationCode
     ) {}
 
-    // 이메일 인증 응답
+    @Schema(description = "이메일 인증 응답")
     public record EmailVerificationResponse(
+            @Schema(description = "처리 성공 여부", example = "true")
             boolean success,
+            
+            @Schema(description = "응답 메시지", example = "인증 이메일이 발송되었습니다.")
             String message
     ) {}
 }

--- a/FreeMarket/src/main/java/com/freemarket/freemarket/global/auth/api/dto/PasswordDto.java
+++ b/FreeMarket/src/main/java/com/freemarket/freemarket/global/auth/api/dto/PasswordDto.java
@@ -1,5 +1,6 @@
 package com.freemarket.freemarket.global.auth.api.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
@@ -7,24 +8,33 @@ import lombok.Builder;
 
 public class PasswordDto {
 
+    @Schema(description = "비밀번호 재설정 요청")
     public record PasswordResetRequest(
+            @Schema(description = "사용자 이메일 주소", example = "user@example.com")
             @NotBlank(message = "이메일은 필수 입력값입니다.")
             @Email(message = "이메일 형식이 올바르지 않습니다.")
             String email
     ) {}
 
+    @Schema(description = "비밀번호 재설정 검증 요청")
     public record PasswordResetVerifyRequest(
+            @Schema(description = "비밀번호 재설정 토큰", example = "1234567890abcdef")
             @NotBlank(message = "토큰은 필수 입력값입니다.")
             String token,
 
+            @Schema(description = "새 비밀번호 (최소 8자 이상)", example = "newPassword123")
             @NotBlank(message = "새 비밀번호는 필수 입력값입니다.")
             @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
             String newPassword
     ) {}
 
     @Builder
+    @Schema(description = "비밀번호 재설정 응답")
     public record PasswordResetResponse(
+            @Schema(description = "처리 성공 여부", example = "true")
             boolean success,
+            
+            @Schema(description = "응답 메시지", example = "비밀번호가 성공적으로 변경되었습니다.")
             String message
     ) {}
 }

--- a/FreeMarket/src/main/java/com/freemarket/freemarket/global/common/ResponseDTO.java
+++ b/FreeMarket/src/main/java/com/freemarket/freemarket/global/common/ResponseDTO.java
@@ -1,5 +1,6 @@
 package com.freemarket.freemarket.global.common;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -7,11 +8,21 @@ import java.time.LocalDateTime;
 
 @Getter
 @Builder
+@Schema(description = "통합 응답 DTO")
 public class ResponseDTO<T> {
+    @Schema(description = "요청 성공 여부", example = "true")
     private final boolean success;
+    
+    @Schema(description = "HTTP 상태 코드", example = "200")
     private final int status;
+    
+    @Schema(description = "응답 메시지", example = "요청이 성공했습니다.")
     private final String message;
+    
+    @Schema(description = "응답 데이터")
     private final T data;
+    
+    @Schema(description = "응답 시간", example = "2025-04-21T12:00:00")
     private final LocalDateTime timestamp;
 
     public static <T> ResponseDTO<T> success(T data) {
@@ -23,6 +34,7 @@ public class ResponseDTO<T> {
                 .timestamp(LocalDateTime.now())
                 .build();
     }
+    
     public static <T> ResponseDTO<T> success(T data, String message) {
         return ResponseDTO.<T>builder()
                 .success(true)

--- a/FreeMarket/src/main/java/com/freemarket/freemarket/product/api/dto/ProductDto.java
+++ b/FreeMarket/src/main/java/com/freemarket/freemarket/product/api/dto/ProductDto.java
@@ -4,6 +4,7 @@ import com.freemarket.freemarket.product.domain.Product;
 import com.freemarket.freemarket.product.domain.ProductCategory;
 import com.freemarket.freemarket.product.domain.ProductImage;
 import com.freemarket.freemarket.product.domain.ProductStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -14,56 +15,91 @@ import java.util.stream.Collectors;
 
 public class ProductDto {
 
+    @Schema(description = "상품 생성 요청")
     public record CreateRequest(
+            @Schema(description = "상품명", example = "새 노트북")
             @NotBlank(message = "상품명은 필수 입력값입니다.")
             String name,
 
+            @Schema(description = "상품 설명", example = "거의 사용하지 않은 노트북입니다.")
             String description,
 
+            @Schema(description = "가격", example = "1000000")
             @NotNull(message = "가격은 필수 입력값입니다.")
             @Min(value = 0)
             Long price,
 
+            @Schema(description = "재고 수량", example = "1")
             @NotNull(message = "재고는 필수 입력값입니다.")
             @Min(value = 1, message = "재고는 최소 1개 이상이어야 합니다.")
             Integer stock,
 
+            @Schema(description = "상품 카테고리", example = "ELECTRONICS")
             @NotNull(message = "카테고리는 필수 입력값입니다.")
             ProductCategory category
     ) {}
 
+    @Schema(description = "상품 수정 요청")
     public record UpdateRequest(
+            @Schema(description = "상품명", example = "새 노트북")
             @NotBlank(message = "상품명은 필수 입력값입니다.")
             String name,
 
+            @Schema(description = "상품 설명", example = "거의 사용하지 않은 노트북입니다.")
             String description,
 
+            @Schema(description = "가격", example = "900000")
             @NotNull(message = "가격은 필수 입력값입니다.")
             @Min(value = 100, message = "가격은 최소 100원 이상이어야 합니다.")
             Long price,
 
+            @Schema(description = "재고 수량", example = "1")
             @NotNull(message = "재고는 필수 입력값입니다.")
             @Min(value = 1, message = "재고는 최소 1개 이상이어야 합니다.")
             Integer stock,
 
+            @Schema(description = "상품 카테고리", example = "ELECTRONICS")
             @NotNull(message = "카테고리는 필수 입력값입니다.")
             ProductCategory category,
 
+            @Schema(description = "상품 상태", example = "ACTIVE")
             ProductStatus status
     ){}
 
     @Builder
+    @Schema(description = "상품 응답")
     public record ProductResponse(
+            @Schema(description = "상품 ID", example = "1")
             Long id,
+            
+            @Schema(description = "상품명", example = "새 노트북")
             String name,
+            
+            @Schema(description = "상품 설명", example = "거의 사용하지 않은 노트북입니다.")
             String description,
+            
+            @Schema(description = "가격", example = "1000000")
             Long price,
+            
+            @Schema(description = "재고 수량", example = "1")
             Integer stock,
+            
+            @Schema(description = "카테고리 표시명", example = "전자기기")
             String category,
+            
+            @Schema(description = "상품 상태", example = "판매중")
             String status,
+            
+            @Schema(description = "썸네일 이미지 URL", example = "https://example.com/thumbnail.jpg")
             String thumbnailUrl,
+            
+            @Schema(description = "이미지 URL 목록")
             List<String> imageUrls,
+            
+            @Schema(description = "판매자 ID", example = "123")
             Long sellerId,
+            
+            @Schema(description = "판매자 이름", example = "홍길동")
             String sellerName
     ) {
         public static ProductResponse from(Product product) {

--- a/FreeMarket/src/main/java/com/freemarket/freemarket/user/api/dto/UserDto.java
+++ b/FreeMarket/src/main/java/com/freemarket/freemarket/user/api/dto/UserDto.java
@@ -1,6 +1,7 @@
 package com.freemarket.freemarket.user.api.dto;
 
 import com.freemarket.freemarket.user.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
@@ -8,19 +9,25 @@ import lombok.Builder;
 
 public class UserDto {
 
+    @Schema(description = "프로필 업데이트 요청")
     public record ProfileUpdateRequest(
+            @Schema(description = "사용자 이름", example = "홍길동")
             @NotBlank(message = "이름은 필수 입력값입니다.")
             String name,
 
+            @Schema(description = "휴대폰 번호", example = "010-1234-5678")
             @Pattern(regexp = "^01(?:0|1|[6-9])[.-]?(\\d{3}|\\d{4})[.-]?(\\d{4})$", message = "휴대폰 번호 형식이 올바르지 않습니다.")
             String phone
     ) {
     }
 
+    @Schema(description = "비밀번호 변경 요청")
     public record PasswordChangeRequest(
+            @Schema(description = "현재 비밀번호", example = "currentPass123")
             @NotBlank(message = "현재 비밀번호는 필수 입력값입니다.")
             String currentPassword,
 
+            @Schema(description = "새 비밀번호", example = "newPass456")
             @NotBlank(message = "새 비밀번호는 필수 입력값입니다.")
             @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
             String newPassword
@@ -28,11 +35,21 @@ public class UserDto {
     }
 
     @Builder
+    @Schema(description = "사용자 응답 정보")
     public record UserResponse(
+            @Schema(description = "사용자 ID", example = "1")
             Long id,
+
+            @Schema(description = "이메일", example = "user@example.com")
             String email,
+
+            @Schema(description = "이름", example = "홍길동")
             String name,
+
+            @Schema(description = "휴대폰 번호", example = "010-1234-5678")
             String phone,
+
+            @Schema(description = "사용자 역할", example = "일반 사용자")
             String role
     ) {
         public static UserResponse from(User user) {

--- a/FreeMarket/src/main/java/com/freemarket/freemarket/user/api/dto/UserProfileDto.java
+++ b/FreeMarket/src/main/java/com/freemarket/freemarket/user/api/dto/UserProfileDto.java
@@ -1,5 +1,6 @@
 package com.freemarket.freemarket.user.api.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
@@ -7,57 +8,110 @@ import java.util.List;
 
 public class UserProfileDto {
 
-    // 판매 상품 내역 DTO
     @Builder
+    @Schema(description = "판매 상품 내역")
     public record SellingProductResponse(
+            @Schema(description = "상품 ID", example = "1")
             Long productId,
+            
+            @Schema(description = "상품명", example = "새 노트북")
             String name,
+            
+            @Schema(description = "가격", example = "1000000")
             Long price,
+            
+            @Schema(description = "카테고리", example = "전자기기")
             String category,
+            
+            @Schema(description = "상품 상태", example = "판매중")
             String status,
+            
+            @Schema(description = "썸네일 URL", example = "https://example.com/thumbnail.jpg")
             String thumbnailUrl,
+            
+            @Schema(description = "구매자 이름", example = "김철수")
             String buyerName,
+            
+            @Schema(description = "판매 완료 날짜", example = "2025-04-21T12:00:00")
             LocalDateTime soldDate,
+            
+            @Schema(description = "상품 등록 날짜", example = "2025-04-20T10:00:00")
             LocalDateTime createdDate
     ) {}
 
-    // 판매 내역 페이지 응답 DTO
     @Builder
+    @Schema(description = "판매 내역 페이지 응답")
     public record SellingHistoryResponse(
+        @Schema(description = "판매 중인 상품 목록")
         List<SellingProductResponse> activeProducts,
+        
+        @Schema(description = "판매 완료된 상품 목록")
         List<SellingProductResponse> soldProducts,
+        
+        @Schema(description = "총 상품 수", example = "10")
         int totalProductCount
     ) {}
 
-    // 구매 내역 DTO
     @Builder
+    @Schema(description = "구매 내역 항목")
     public record PurchaseItem(
+        @Schema(description = "상품 ID", example = "1")
         Long productId,
+        
+        @Schema(description = "상품명", example = "중고 책")
         String productName,
+        
+        @Schema(description = "구매 가격", example = "15000")
         Long price,
+        
+        @Schema(description = "카테고리", example = "도서")
         String category,
+        
+        @Schema(description = "썸네일 URL", example = "https://example.com/thumbnail.jpg")
         String thumbnailUrl,
+        
+        @Schema(description = "판매자 이름", example = "이영희")
         String sellerName,
+        
+        @Schema(description = "구매 날짜", example = "2025-04-20T14:30:00")
         LocalDateTime purchaseDate
     ) {}
 
-    // 구매 내역 페이지 응답 DTO
     @Builder
+    @Schema(description = "구매 내역 페이지 응답")
     public record PurchaseHistoryResponse(
+            @Schema(description = "구매 내역 목록")
             List<PurchaseItem> purchases,
+            
+            @Schema(description = "총 구매 수", example = "5")
             int totalPurchaseCount
     ) {}
 
-    // 프로필 요약 정보 DTO
     @Builder
+    @Schema(description = "프로필 요약 정보")
     public record ProfileSummaryResponse(
+            @Schema(description = "사용자 ID", example = "1")
             Long userId,
+            
+            @Schema(description = "이메일", example = "user@example.com")
             String email,
+            
+            @Schema(description = "이름", example = "홍길동")
             String name,
+            
+            @Schema(description = "총 판매 중인 상품 수", example = "3")
             int totalSellingCount,
+            
+            @Schema(description = "총 판매 완료 수", example = "7")
             int totalSoldCount,
+            
+            @Schema(description = "총 구매 수", example = "15")
             int totalPurchaseCount,
+            
+            @Schema(description = "평균 평점", example = "4.5")
             double averageRating,
+            
+            @Schema(description = "가입 날짜", example = "2025-01-01T09:00:00")
             LocalDateTime joinDate
     ) {}
 }


### PR DESCRIPTION
- 현재 프로젝트의 DTO 클래스들에 Swagger 문서화를 위한 @Schema 어노테이션이 누락되어 API 문서화가 완전하지 않은 상태다
- API의 요청/응답 모델에 대한 명확한 설명과 예제를 제공하기 위해 모든 DTO에 Swagger 어노테이션을 추가한다.

## 작업 상세
다음 DTO 클래스들에 @Schema 어노테이션을 추가하여 API 문서화를 개선

### ProductDto
- 상품 생성, 수정, 응답 레코드에 설명과 예제 추가
- 각 필드별 상세 설명과 타입별 예제값 포함

### AuthDto
- 회원가입, 로그인, 토큰 관련 요청/응답에 설명 추가
- JWT 토큰 예시 및 데이터 포맷 설명 포함

### EmailVerificationDto
- 학교 이메일 인증 관련 요청/응답에 설명 추가
- 인증 코드 형식 및 응답 메시지 예시 포함

### PasswordDto
- 비밀번호 재설정 요청/응답에 설명 추가
- 토큰 및 비밀번호 제약사항 설명 포함

### UserProfileDto
- 사용자 프로필 정보, 판매/구매 내역에 설명 추가
- 날짜 형식 및 통계 데이터 예시 포함

### ResponseDTO
- 공통 응답 형식에 대한 설명과 각 필드 예시 추가
- HTTP 상태 코드 및 성공/실패 응답 형식 설명

---
### 기대 효과
- Swagger UI에서 모든 API 요청/응답에 대한 상세한 설명과 예제 제공
- 프론트엔드 개발자의 API 이해도 향상
- API 사용법에 대한 문서화 자동화로 개발 생산성 향상