### PR TITLE
Feat: 상품 관심 등록과 상품 조회수 기능 #45

### DIFF
--- a/FreeMarket/src/main/java/com/freemarket/freemarket/product/api/ProductController.java
+++ b/FreeMarket/src/main/java/com/freemarket/freemarket/product/api/ProductController.java
@@ -4,6 +4,7 @@ import com.freemarket.freemarket.global.common.ResponseDTO;
 import com.freemarket.freemarket.global.security.CustomUserDetails;
 import com.freemarket.freemarket.product.api.dto.ProductDto;
 import com.freemarket.freemarket.product.application.ProductService;
+import com.freemarket.freemarket.product.application.ProductViewService;
 import com.freemarket.freemarket.product.domain.ProductCategory;
 import com.freemarket.freemarket.product.domain.ProductStatus;
 import io.swagger.v3.oas.annotations.Operation;
@@ -37,6 +38,7 @@ import java.util.List;
 public class ProductController {
 
     private final ProductService productService;
+    private final ProductViewService viewService;
 
     @Operation(summary = "상품 등록", description = "새로운 상품을 등록합니다. 상품명, 가격, 수량, 카테고리는 필수 입력 항목입니다.")
     @ApiResponses(value = {
@@ -49,7 +51,7 @@ public class ProductController {
                     content = @Content(schema = @Schema(implementation = ResponseDTO.class)))
     })
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<ResponseDTO<ProductDto.ProductResponse>> createProduct(
+    public ResponseEntity<ResponseDTO<ProductDto.ProductBaseResponse>> createProduct(
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
             @Parameter(description = "상품 등록 정보", required = true, content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
             @Valid @RequestPart("request") ProductDto.CreateRequest request,
@@ -57,7 +59,7 @@ public class ProductController {
 
 
         log.info("상품 등록 요청: 사용자 ID {}", userDetails.getUserId());
-        ProductDto.ProductResponse response = productService.createProduct(userDetails.getUserId(), request, images);
+        ProductDto.ProductBaseResponse response = productService.createProduct(userDetails.getUserId(), request, images);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(ResponseDTO.success(response, "상품이 성공적으로 등록되었습니다."));
     }
@@ -72,7 +74,7 @@ public class ProductController {
             @ApiResponse(responseCode = "404", description = "상품을 찾을 수 없음")
     })
     @PatchMapping(value = "/{productId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<ResponseDTO<ProductDto.ProductResponse>> updateProduct(
+    public ResponseEntity<ResponseDTO<ProductDto.ProductBaseResponse>> updateProduct(
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
             @Parameter(description = "상품 ID", required = true) @PathVariable Long productId,
             @Parameter(description = "상품 정보 (JSON)", required = true, content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
@@ -82,7 +84,7 @@ public class ProductController {
             ) {
 
         log.info("상품 수정 요청: 상품 ID {}, 사용자 ID {}", productId, userDetails.getUserId());
-        ProductDto.ProductResponse response = productService.updateProduct(userDetails.getUserId(), productId, request, newImages, deleteImageIds);
+        ProductDto.ProductBaseResponse response = productService.updateProduct(userDetails.getUserId(), productId, request, newImages, deleteImageIds);
 
         return ResponseEntity.ok(ResponseDTO.success(response, "상품이 성공적으로 수정되었습니다."));
     }
@@ -93,11 +95,14 @@ public class ProductController {
             @ApiResponse(responseCode = "404", description = "상품을 찾을 수 없음")
     })
     @GetMapping("/{productId}")
-    public ResponseEntity<ResponseDTO<ProductDto.ProductResponse>> getProduct(
-        @Parameter(description = "상품 ID", required = true) @PathVariable Long productId) {
+    public ResponseEntity<ResponseDTO<ProductDto.ProductDetailResponse>> getProduct(
+        @Parameter(description = "상품 ID", required = true) @PathVariable Long productId,
+        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
 
+        // 조회수 증가
+        viewService.incrementViewCount(productId);
         log.info("상품 조회 요청: 상품 ID {}", productId);
-        ProductDto.ProductResponse response = productService.getProduct(productId);
+        ProductDto.ProductDetailResponse response = productService.getProduct(productId, userDetails.getUserId());
 
         return ResponseEntity.ok(ResponseDTO.success(response));
     }
@@ -107,7 +112,7 @@ public class ProductController {
             @ApiResponse(responseCode = "200", description = "상품 목록 조회 성공")
     })
     @GetMapping
-    public ResponseEntity<ResponseDTO<Page<ProductDto.ProductResponse>>> getProducts(
+    public ResponseEntity<ResponseDTO<Page<ProductDto.ProductDetailResponse>>> getProducts(
             @Parameter(description = "검색 키워드 (상품명, 설명에서 검색)")
             @RequestParam(required = false) String keyword,
 
@@ -115,10 +120,12 @@ public class ProductController {
             @RequestParam(required = false) ProductStatus status,
 
             @Parameter(description = "페이지네이션 정보 (기본값: 페이지 크기 10, 생성일 기준 내림차순 정렬)")
-            @PageableDefault(size = 10, sort = "createdDate") Pageable pageable) {
+            @PageableDefault(size = 10, sort = "createdDate") Pageable pageable,
+
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
 
         log.info("상품 목록 조회 요청: 키워드 {}, 상태 {}", keyword, status);
-        Page<ProductDto.ProductResponse> response = productService.getProducts(keyword, status, pageable);
+        Page<ProductDto.ProductDetailResponse> response = productService.getProducts(keyword, status, pageable, userDetails.getUserId());
 
         return ResponseEntity.ok(ResponseDTO.success(response));
     }
@@ -129,7 +136,7 @@ public class ProductController {
             @ApiResponse(responseCode = "400", description = "잘못된 카테고리 요청")
     })
     @GetMapping("/category/{category}")
-    public ResponseEntity<ResponseDTO<Page<ProductDto.ProductResponse>>> getProductsByCategory(
+    public ResponseEntity<ResponseDTO<Page<ProductDto.ProductDetailResponse>>> getProductsByCategory(
             @Parameter(description = "상품 카테고리 (BOOKS, ELECTRONICS, FASHION 등)", required = true)
             @PathVariable ProductCategory category,
 
@@ -140,10 +147,12 @@ public class ProductController {
             @RequestParam(required = false) ProductStatus status,
 
             @Parameter(description = "페이지네이션 정보")
-            @PageableDefault(size = 10, sort = "createdDate") Pageable pageable) {
+            @PageableDefault(size = 10, sort = "createdDate") Pageable pageable,
+
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
 
         log.info("카테고리별 상품 조회 요청: 카테고리 {}, 키워드 {}, 상태 {}", category, keyword, status);
-        Page<ProductDto.ProductResponse> response = productService.getProductsByCategory(category, keyword, status, pageable);
+        Page<ProductDto.ProductDetailResponse> response = productService.getProductsByCategory(category, keyword, status, pageable, userDetails.getUserId());
 
         return ResponseEntity.ok(ResponseDTO.success(response));
     }
@@ -175,7 +184,7 @@ public class ProductController {
             @ApiResponse(responseCode = "404", description = "상품을 찾을 수 없음")
     })
     @PostMapping("/{productId}/sold")
-    public ResponseEntity<ResponseDTO<ProductDto.ProductResponse>> markProductAsSold(
+    public ResponseEntity<ResponseDTO<ProductDto.ProductBaseResponse>> markProductAsSold(
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
             @Parameter(description = "상품 ID", required = true) @PathVariable Long productId,
             @Parameter(description = "구매자 ID", required = true) @RequestParam Long buyerId) {
@@ -183,7 +192,7 @@ public class ProductController {
         log.info("상품 판매완료 처리 요청: 상품 ID {}, 판매자 ID {}, 구매자 ID {}",
                 productId, userDetails.getUserId(), buyerId);
 
-        ProductDto.ProductResponse response = productService.markProductAsSold(
+        ProductDto.ProductBaseResponse response = productService.markProductAsSold(
                 userDetails.getUserId(), productId, buyerId);
 
         return ResponseEntity.ok(ResponseDTO.success(response, "상품이 판매완료 처리되었습니다."));
@@ -198,13 +207,13 @@ public class ProductController {
             @ApiResponse(responseCode = "404", description = "상품을 찾을 수 없음")
     })
     @PostMapping("/{productId}/cancel-sold")
-    public ResponseEntity<ResponseDTO<ProductDto.ProductResponse>> cancelProductSold(
+    public ResponseEntity<ResponseDTO<ProductDto.ProductBaseResponse>> cancelProductSold(
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
             @Parameter(description = "상품 ID", required = true) @PathVariable Long productId) {
 
         log.info("판매완료 취소 요청: 상품 ID {}, 판매자 ID {}", productId, userDetails.getUserId());
 
-        ProductDto.ProductResponse response = productService.cancelProductSold(
+        ProductDto.ProductBaseResponse response = productService.cancelProductSold(
                 userDetails.getUserId(), productId);
 
         return ResponseEntity.ok(ResponseDTO.success(response, "판매완료가 취소되었습니다."));

--- a/FreeMarket/src/main/java/com/freemarket/freemarket/product/api/ProductWishlistController.java
+++ b/FreeMarket/src/main/java/com/freemarket/freemarket/product/api/ProductWishlistController.java
@@ -1,0 +1,72 @@
+package com.freemarket.freemarket.product.api;
+
+import com.freemarket.freemarket.global.common.ResponseDTO;
+import com.freemarket.freemarket.global.security.CustomUserDetails;
+import com.freemarket.freemarket.product.api.dto.ProductDto;
+import com.freemarket.freemarket.product.application.ProductWishlistService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/products")
+@RequiredArgsConstructor
+@Tag(name = "상품 관심 등록 API", description = "상품 관심 등록(찜하기) 관련 API")
+public class ProductWishlistController {
+
+    private final ProductWishlistService wishlistService;
+
+    @Operation(summary = "상품 관심 등록/취소", description = "상품을 관심 목록에 추가하거나 제거합니다. 이미 관심 등록된 상품은 취소됩니다.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공적으로 처리됨",
+                    content = @Content(schema = @Schema(implementation = Map.class))
+            ),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "404", description = "상품을 찾을 수 없음")
+    })
+    @PostMapping("/{productId}/wishlist")
+    public ResponseEntity<Map<String, Object>> toggleWishlist(
+            @Parameter(description = "관심 등록/취소할 상품 ID", required = true)
+            @PathVariable Long productId,
+
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        boolean isAdded = wishlistService.toggleWishlist(userDetails.getUserId(), productId);
+        Long wishlistCount = wishlistService.getWishlistCount(productId);
+
+        return ResponseEntity.ok(Map.of(
+                "added", isAdded,
+                "count", wishlistCount
+        ));
+    }
+
+    @Operation(summary = "사용자의 관심 상품 목록 조회", description = "현재 로그인한 사용자가 관심 등록한 상품 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공적으로 조회됨",
+                    content = @Content(schema = @Schema(implementation = List.class))
+            ),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+    })
+    @GetMapping("/wishlist")
+    public ResponseEntity<ResponseDTO<List<ProductDto.ProductBaseResponse>>> getUserWishlist(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        List<ProductDto.ProductBaseResponse> wishlist = wishlistService.getUserWishlistDto(userDetails.getUserId());
+        return ResponseEntity.ok(ResponseDTO.success(wishlist));
+    }
+}

--- a/FreeMarket/src/main/java/com/freemarket/freemarket/product/api/dto/ProductDto.java
+++ b/FreeMarket/src/main/java/com/freemarket/freemarket/product/api/dto/ProductDto.java
@@ -37,7 +37,8 @@ public class ProductDto {
             @Schema(description = "상품 카테고리", example = "ELECTRONICS")
             @NotNull(message = "카테고리는 필수 입력값입니다.")
             ProductCategory category
-    ) {}
+    ) {
+    }
 
     @Schema(description = "상품 수정 요청")
     public record UpdateRequest(
@@ -64,46 +65,48 @@ public class ProductDto {
 
             @Schema(description = "상품 상태", example = "ACTIVE")
             ProductStatus status
-    ){}
+    ) {
+    }
 
+    // 기본 상품 정보 (등록, 수정 결과용)
     @Builder
-    @Schema(description = "상품 응답")
-    public record ProductResponse(
+    @Schema(description = "기본 상품 정보 응답")
+    public record ProductBaseResponse(
             @Schema(description = "상품 ID", example = "1")
             Long id,
-            
+
             @Schema(description = "상품명", example = "새 노트북")
             String name,
-            
+
             @Schema(description = "상품 설명", example = "거의 사용하지 않은 노트북입니다.")
             String description,
-            
+
             @Schema(description = "가격", example = "1000000")
             Long price,
-            
+
             @Schema(description = "재고 수량", example = "1")
             Integer stock,
-            
+
             @Schema(description = "카테고리 표시명", example = "전자기기")
             String category,
-            
+
             @Schema(description = "상품 상태", example = "판매중")
             String status,
-            
+
             @Schema(description = "썸네일 이미지 URL", example = "https://example.com/thumbnail.jpg")
             String thumbnailUrl,
-            
+
             @Schema(description = "이미지 URL 목록")
             List<String> imageUrls,
-            
+
             @Schema(description = "판매자 ID", example = "123")
             Long sellerId,
-            
+
             @Schema(description = "판매자 이름", example = "홍길동")
             String sellerName
     ) {
-        public static ProductResponse from(Product product) {
-            return ProductResponse.builder()
+        public static ProductBaseResponse from(Product product) {
+            return ProductBaseResponse.builder()
                     .id(product.getId())
                     .name(product.getName())
                     .description(product.getDescription())
@@ -120,4 +123,41 @@ public class ProductDto {
                     .build();
         }
     }
+
+    // 상품 조회 응답 (통계 정보 포함)
+    @Builder
+    @Schema(description = "상품 상세 조회 응답")
+    public record ProductDetailResponse(
+            @Schema(description = "상품 기본 정보")
+            ProductBaseResponse product,
+
+            @Schema(description = "상품 통계 정보")
+            ProductStatsResponse stats
+    ) {
+        public static ProductDetailResponse from(
+                Product product,
+                Long viewCount,
+                Long wishlistCount,
+                boolean isWishlisted) {
+
+            return ProductDetailResponse.builder()
+                    .product(ProductBaseResponse.from(product))
+                    .stats(new ProductStatsResponse(viewCount, wishlistCount, isWishlisted))
+                    .build();
+        }
+    }
+
+    // 상품 통계 정보
+    @Builder
+    @Schema(description = "상품 통계 정보")
+    public record ProductStatsResponse(
+            @Schema(description = "조회수", example = "42")
+            Long viewCount,
+
+            @Schema(description = "관심 등록 수", example = "7")
+            Long wishlistCount,
+
+            @Schema(description = "현재 사용자의 관심 등록 여부", example = "true")
+            boolean isWishlisted
+    ) {}
 }

--- a/FreeMarket/src/main/java/com/freemarket/freemarket/product/api/dto/ProductWithStatsDto.java
+++ b/FreeMarket/src/main/java/com/freemarket/freemarket/product/api/dto/ProductWithStatsDto.java
@@ -1,0 +1,35 @@
+package com.freemarket.freemarket.product.api.dto;
+
+import com.freemarket.freemarket.product.domain.Product;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "상품과 관련 통계 정보 포함 DTO")
+public record ProductWithStatsDto(
+        @Schema(description = "상품 정보", required = true)
+        Product product,
+
+        @Schema(description = "상품 조회수", example = "42")
+        Long viewCount,
+
+        @Schema(description = "관심 등록 수", example = "7")
+        Long wishlistCount,
+
+        @Schema(description = "현재 사용자의 관심 등록 여부", example = "true")
+        boolean isWishlisted
+) {
+
+    public ProductWithStatsDto {
+        // null 체크 및 기본값 설정
+        viewCount = viewCount != null ? viewCount : 0L;
+        wishlistCount = wishlistCount != null ? wishlistCount : 0L;
+    }
+
+    public ProductDto.ProductDetailResponse toProductDetailResponse() {
+        return ProductDto.ProductDetailResponse.from(
+                product,
+                viewCount,
+                wishlistCount,
+                isWishlisted
+        );
+    }
+}

--- a/FreeMarket/src/main/java/com/freemarket/freemarket/product/application/ProductService.java
+++ b/FreeMarket/src/main/java/com/freemarket/freemarket/product/application/ProductService.java
@@ -3,6 +3,7 @@ package com.freemarket.freemarket.product.application;
 import com.freemarket.freemarket.global.email.exception.EmailVerificationException;
 import com.freemarket.freemarket.global.file.application.FileStorageService;
 import com.freemarket.freemarket.product.api.dto.ProductDto;
+import com.freemarket.freemarket.product.api.dto.ProductWithStatsDto;
 import com.freemarket.freemarket.product.domain.*;
 import com.freemarket.freemarket.product.exception.ProductException;
 import com.freemarket.freemarket.user.domain.User;
@@ -29,10 +30,12 @@ public class ProductService {
     private final ProductRepository productRepository;
     private final UserRepository userRepository;
     private final FileStorageService fileStorageService;
+    private final ProductViewService viewService;
+    private final ProductWishlistService wishlistService;
 
     // 상품 등록
     @Transactional
-    public ProductDto.ProductResponse createProduct(Long userId, ProductDto.CreateRequest request, List<MultipartFile> images) throws BadRequestException {
+    public ProductDto.ProductBaseResponse createProduct(Long userId, ProductDto.CreateRequest request, List<MultipartFile> images) throws BadRequestException {
         User seller = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException.UserNotFoundException(userId));
 
@@ -68,7 +71,7 @@ public class ProductService {
             }
             Product savedProduct = productRepository.save(product);
             log.info("상품 등록 완료: 상품명 {}, 판매자 ID {}", request.name(), userId);
-            return ProductDto.ProductResponse.from(savedProduct);
+            return ProductDto.ProductBaseResponse.from(savedProduct);
         } catch (Exception e) {
             log.error("상품 등록 중 오류 발생: 사용자 ID {}", userId, e);
             uploadedFiles.forEach(uploadedFile -> {
@@ -81,7 +84,7 @@ public class ProductService {
 
     // 상품 수정
     @Transactional
-    public ProductDto.ProductResponse updateProduct(Long userId, Long productId, ProductDto.UpdateRequest request,
+    public ProductDto.ProductBaseResponse updateProduct(Long userId, Long productId, ProductDto.UpdateRequest request,
                                                     List<MultipartFile> newImages, List<Long> deleteImageIds) {
         Product product = getProductWithSellerCheck(productId, userId);
         product.update(request.name(), request.description(), request.price(), request.stock(), request.category());
@@ -127,7 +130,7 @@ public class ProductService {
             }
 
             log.info("상품 수정 완료: 상품 ID {}, 판매자 ID {}", productId, userId);
-            return ProductDto.ProductResponse.from(product); // 변경 감지로 업데이트됨
+            return ProductDto.ProductBaseResponse.from(product); // 변경 감지로 업데이트됨
         } catch (Exception e) { // 롤백 로직
             log.error("상품 수정 중 오류 발생: 상품 ID {}", productId, e);
             newlyUploadedFiles.forEach(uploadedFile -> {
@@ -139,22 +142,30 @@ public class ProductService {
     }
 
     // 상품 단건 조회
-    public ProductDto.ProductResponse getProduct(Long productId) {
+    public ProductDto.ProductDetailResponse getProduct(Long productId, Long userId) {
         Product product = findProduct(productId);
-        return ProductDto.ProductResponse.from(product);
+
+        // 조회수
+        Long viewCount = viewService.getViewCount(productId);
+        // 관심 등록 수
+        Long wishlistCount = wishlistService.getWishlistCount(productId);
+
+        // 현재 사용자의 관심 등록 여부
+        boolean isWishlisted = userId != null ? wishlistService.isWishlisted(userId, productId) : false;
+        return ProductDto.ProductDetailResponse.from(product, viewCount, wishlistCount, isWishlisted);
     }
 
     // 상품 목록 조회
-    public Page<ProductDto.ProductResponse> getProducts(String keyword, ProductStatus status, Pageable pageable) {
-        return productRepository.findAllWithFilters(keyword, status, pageable)
-                .map(ProductDto.ProductResponse::from);
+    public Page<ProductDto.ProductDetailResponse> getProducts(String keyword, ProductStatus status, Pageable pageable, Long userId) {
+        return productRepository.findAllWithStatsAndWishlist(keyword, status, pageable, userId)
+                .map(ProductWithStatsDto::toProductDetailResponse);
     }
 
     // 카테고리별 상품 조회
-    public Page<ProductDto.ProductResponse> getProductsByCategory(ProductCategory category, String keyword, ProductStatus status,
-                                                                  Pageable pageable) {
-        return productRepository.findByCategoryWithFilters(category, keyword, status, pageable)
-                .map(ProductDto.ProductResponse::from);
+    public Page<ProductDto.ProductDetailResponse> getProductsByCategory(ProductCategory category, String keyword, ProductStatus status,
+                                                                  Pageable pageable, Long userId) {
+        return productRepository.findByCategoryWithStatsAndWishlist(category, keyword, status, pageable, userId)
+                .map(ProductWithStatsDto::toProductDetailResponse);
     }
 
     // 상품 삭제
@@ -167,7 +178,7 @@ public class ProductService {
 
     // 판매 완료 처리
     @Transactional
-    public ProductDto.ProductResponse markProductAsSold(Long sellerId, Long productId, Long buyerId) {
+    public ProductDto.ProductBaseResponse markProductAsSold(Long sellerId, Long productId, Long buyerId) {
         Product product = getProductWithSellerCheck(productId, sellerId);
 
         if (product.getStatus() == ProductStatus.SOLD_OUT) {
@@ -181,12 +192,12 @@ public class ProductService {
 
         log.info("상품 판매완료 처리: 상품 ID {}, 판매자 ID {}, 구매자 ID {}", productId, sellerId, buyerId);
 
-        return ProductDto.ProductResponse.from(product);
+        return ProductDto.ProductBaseResponse.from(product);
     }
 
     // 판매완료 취소 처리 메서드
     @Transactional
-    public ProductDto.ProductResponse cancelProductSold(Long sellerId, Long productId) {
+    public ProductDto.ProductBaseResponse cancelProductSold(Long sellerId, Long productId) {
         Product product = getProductWithSellerCheck(productId, sellerId);
 
         if (product.getStatus() != ProductStatus.SOLD_OUT) {
@@ -195,7 +206,7 @@ public class ProductService {
 
         product.cancelSold();
         log.info("판매완료 취소 처리: 상품 ID {}, 판매자 ID {}", productId, sellerId);
-        return ProductDto.ProductResponse.from(product);
+        return ProductDto.ProductBaseResponse.from(product);
     }
 
     // 판매자 권한 확인 후 상품 조회

--- a/FreeMarket/src/main/java/com/freemarket/freemarket/product/application/ProductViewService.java
+++ b/FreeMarket/src/main/java/com/freemarket/freemarket/product/application/ProductViewService.java
@@ -1,0 +1,43 @@
+package com.freemarket.freemarket.product.application;
+
+import com.freemarket.freemarket.product.domain.Product;
+import com.freemarket.freemarket.product.domain.ProductRepository;
+import com.freemarket.freemarket.product.domain.ProductViewCount;
+import com.freemarket.freemarket.product.domain.ProductViewCountRepository;
+import com.freemarket.freemarket.product.exception.ProductException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ProductViewService {
+
+    private final ProductRepository productRepository;
+    private final ProductViewCountRepository viewCountRepository;
+
+    @Transactional
+    public void incrementViewCount(Long productId) {
+        Product product = getProduct(productId);
+        ProductViewCount viewCount = viewCountRepository.findByProductId(productId)
+                .orElseGet(() -> {
+                   ProductViewCount newViewCount = ProductViewCount.builder()
+                           .product(product)
+                           .build();
+                   return viewCountRepository.save(newViewCount);
+                });
+
+        viewCount.incrementCount();
+    }
+
+    public Long getViewCount(Long productId) {
+        return viewCountRepository.findByProductId(productId)
+                .map(ProductViewCount::getCount)
+                .orElse(0L);
+    }
+
+    private Product getProduct(Long productId) {
+        return productRepository.findById(productId).orElseThrow(() -> new ProductException.ProductNotFoundException(productId));
+    }
+}

--- a/FreeMarket/src/main/java/com/freemarket/freemarket/product/application/ProductWishlistService.java
+++ b/FreeMarket/src/main/java/com/freemarket/freemarket/product/application/ProductWishlistService.java
@@ -1,0 +1,83 @@
+package com.freemarket.freemarket.product.application;
+
+import com.freemarket.freemarket.product.api.dto.ProductDto;
+import com.freemarket.freemarket.product.domain.Product;
+import com.freemarket.freemarket.product.domain.ProductRepository;
+import com.freemarket.freemarket.product.domain.ProductWishlist;
+import com.freemarket.freemarket.product.domain.ProductWishlistRepository;
+import com.freemarket.freemarket.product.exception.ProductException;
+import com.freemarket.freemarket.user.domain.User;
+import com.freemarket.freemarket.user.domain.UserRepository;
+import com.freemarket.freemarket.user.exception.UserException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ProductWishlistService {
+
+    private final ProductWishlistRepository productWishlistRepository;
+    private final ProductRepository productRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public boolean toggleWishlist(Long userId, Long productId) {
+        User user = getUser(userId);
+        Product product = getProduct(productId);
+
+        boolean exists = productWishlistRepository.existsByUserAndProduct(user, product);
+
+        if (exists) {
+            productWishlistRepository.deleteByUserAndProduct(user, product);
+            return false; // 관심 상품 취소
+        } else {
+            ProductWishlist wishlist = ProductWishlist.builder()
+                    .user(user)
+                    .product(product)
+                    .build();
+            productWishlistRepository.save(wishlist);
+            return true; // 관심 상품 등록
+        }
+    }
+
+    public List<Product> getUserWishlist(Long userId) {
+        User user = getUser(userId);
+        return productWishlistRepository.findAllByUser(user).stream()
+                .map(ProductWishlist::getProduct)
+                .collect(Collectors.toList());
+    }
+
+    public boolean isWishlisted(Long userId, Long productId) {
+        if (userId == null) {
+            return false;
+        }
+
+        User user = getUser(userId);
+        Product product = getProduct(productId);
+
+        return productWishlistRepository.existsByUserAndProduct(user, product);
+    }
+
+    public Long getWishlistCount(Long productId) {
+        return productWishlistRepository.countByProductId(productId);
+    }
+
+    public List<ProductDto.ProductBaseResponse> getUserWishlistDto(Long userId) {
+        User user = getUser(userId);
+        return productWishlistRepository.findAllByUser(user).stream()
+                .map(wishlist -> ProductDto.ProductBaseResponse.from(wishlist.getProduct()))
+                .collect(Collectors.toList());
+    }
+    private Product getProduct(Long productId) {
+        return productRepository.findById(productId).orElseThrow(() -> new ProductException.ProductNotFoundException(productId));
+    }
+
+    private User getUser(Long userId) {
+        return userRepository.findById(userId).orElseThrow(() -> new UserException.UserNotFoundException(userId));
+    }
+}

--- a/FreeMarket/src/main/java/com/freemarket/freemarket/product/domain/ProductRepositoryCustom.java
+++ b/FreeMarket/src/main/java/com/freemarket/freemarket/product/domain/ProductRepositoryCustom.java
@@ -1,5 +1,7 @@
 package com.freemarket.freemarket.product.domain;
 
+import com.freemarket.freemarket.product.api.dto.ProductDto;
+import com.freemarket.freemarket.product.api.dto.ProductWithStatsDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -8,6 +10,9 @@ public interface ProductRepositoryCustom {
     Page<Product> findAllWithFilters(String keyword, ProductStatus status, Pageable pageable);
 
     // 카테고리별 상품 조회
-    Page<Product> findByCategoryWithFilters(ProductCategory category, String keyword, ProductStatus status,
-                                            Pageable pageable);
+    Page<Product> findByCategoryWithFilters(ProductCategory category, String keyword, ProductStatus status, Pageable pageable);
+
+    // 통계 정보를 함께 조회
+    Page<ProductWithStatsDto> findAllWithStatsAndWishlist(String keyword, ProductStatus status, Pageable pageable, Long userId);
+    Page<ProductWithStatsDto> findByCategoryWithStatsAndWishlist(ProductCategory category, String keyword, ProductStatus status, Pageable pageable, Long userId);
 }

--- a/FreeMarket/src/main/java/com/freemarket/freemarket/product/domain/ProductRepositoryImpl.java
+++ b/FreeMarket/src/main/java/com/freemarket/freemarket/product/domain/ProductRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.freemarket.freemarket.product.domain;
 
+import com.freemarket.freemarket.product.api.dto.ProductWithStatsDto;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
@@ -16,6 +17,8 @@ import java.util.stream.Collectors;
 
 import static com.freemarket.freemarket.product.domain.QProduct.product;
 import static com.freemarket.freemarket.product.domain.QProductImage.productImage;
+import static com.freemarket.freemarket.product.domain.QProductViewCount.productViewCount;
+import static com.freemarket.freemarket.product.domain.QProductWishlist.productWishlist;
 
 @RequiredArgsConstructor
 public class ProductRepositoryImpl implements ProductRepositoryCustom {
@@ -38,6 +41,116 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
 
         // 페이지 조회 및 생성 공통 메서드 호출
         return fetchPagedProductsWithFetchJoin(builder, pageable);
+    }
+
+    @Override
+    public Page<ProductWithStatsDto> findAllWithStatsAndWishlist(String keyword, ProductStatus status, Pageable pageable, Long userId) {
+        BooleanBuilder builder = createBasicCondition(keyword, status, null);
+
+        return fetchPagedProductsWithStats(builder, pageable, userId);
+    }
+
+    @Override
+    public Page<ProductWithStatsDto> findByCategoryWithStatsAndWishlist(ProductCategory category, String keyword, ProductStatus status, Pageable pageable, Long userId) {
+        // 공통 조건을 사용하여 BooleanBuilder 생성
+        BooleanBuilder builder = createBasicCondition(keyword, status, category);
+
+        // 통계 정보를 포함한 페이지 조회 및 생성 메서드 호출
+        return fetchPagedProductsWithStats(builder, pageable, userId);
+    }
+
+    private Page<ProductWithStatsDto> fetchPagedProductsWithStats(BooleanBuilder builder, Pageable pageable, Long userId) {
+        // 페이징된 ID 목록 조회
+        List<Long> productIds = queryFactory
+                .select(product.id)
+                .from(product)
+                .where(builder)
+                .orderBy(product.createdDate.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        if (productIds.isEmpty()) {
+            return Page.empty(pageable);
+        }
+
+        // ID 목록으로 Product와 images를 Fetch Join하여 조회
+        List<Product> products = queryFactory
+                .select(product).distinct()
+                .from(product)
+                .leftJoin(product.images, productImage).fetchJoin()
+                .where(product.id.in(productIds))
+                .orderBy(product.createdDate.desc())
+                .fetch();
+
+        // 조회된 상품들의 조회수 쿼리
+        Map<Long ,Long> viewCountMap = queryFactory
+                .select(productViewCount.product.id, productViewCount.count)
+                .from(productViewCount)
+                .where(productViewCount.product.id.in(productIds))
+                .fetch()
+                .stream()
+                .collect(Collectors.toMap(
+                        tuple -> tuple.get(productViewCount.product.id),
+                        tuple -> tuple.get(productViewCount.count),
+                        (a, b) -> a // 중복 키 발생 시 첫 번째 값 유지
+                ));
+
+        // 조회된 상품들의 관심 등록 수 조회
+        Map<Long, Long> wishlistCountMap = queryFactory
+                .select(productWishlist.product.id, productWishlist.count())
+                .from(productWishlist)
+                .where(productWishlist.product.id.in(productIds))
+                .groupBy(productWishlist.product.id)
+                .fetch()
+                .stream()
+                .collect(Collectors.toMap(
+                        tuple -> tuple.get(productWishlist.product.id),
+                        tuple -> tuple.get(productWishlist.count()),
+                        (a, b) -> a)); // 중복 키 발생 시 첫 번째 값 유지
+
+        // 사용자가 관심 등록한 상품 ID 목록 조회
+        Map<Long, Boolean> isWishlistedMap; // 기본값은 빈 맵
+        if (userId != null) {
+            isWishlistedMap = queryFactory
+                    .select(productWishlist.product.id)
+                    .from(productWishlist)
+                    .where(productWishlist.product.id.in(productIds)
+                            .and(productWishlist.user.id.eq(userId)))
+                    .fetch()
+                    .stream()
+                    .collect(Collectors.toMap(
+                            productId -> productId,
+                            productId -> true,
+                            (a, b) -> a)); // 중복 키 발생 시 첫 번째 값 유지
+        } else {
+            isWishlistedMap = Map.of();
+        }
+
+        // 조회된 상품을 productIds 순서에 맞게 정렬하고 DTO로 변환
+        Map<Long, Product> productMap = products.stream()
+                .collect(Collectors.toMap(Product::getId, p -> p));
+
+        // 최종 DTO 리스트 생성
+        List<ProductWithStatsDto> result = productIds.stream()
+                .map(id -> {
+                    Product p = productMap.get(id);
+                    Long viewCount = viewCountMap.getOrDefault(id, 0L);
+                    Long wishlistCount = wishlistCountMap.getOrDefault(id, 0L);
+                    boolean isWishlisted = isWishlistedMap.getOrDefault(id, false);
+
+                    return new ProductWithStatsDto(p, viewCount, wishlistCount, isWishlisted);
+                })
+                .collect(Collectors.toList());
+
+        // 전체 개수 조회를 위한 쿼리
+        JPAQuery<Long> countQuery = queryFactory
+                .select(product.count())
+                .from(product)
+                .where(builder);
+
+        // 페이지 객체 생성 (count 쿼리 최적화)
+        return PageableExecutionUtils.getPage(result, pageable, countQuery::fetchOne);
     }
 
     // 상품명 또는 설명에 키워드가 포함된 조건

--- a/FreeMarket/src/main/java/com/freemarket/freemarket/product/domain/ProductViewCount.java
+++ b/FreeMarket/src/main/java/com/freemarket/freemarket/product/domain/ProductViewCount.java
@@ -1,0 +1,37 @@
+package com.freemarket.freemarket.product.domain;
+
+import com.freemarket.freemarket.global.auditing.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "product_view_counts")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductViewCount extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "view_count_id")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", unique = true)
+    private Product product;
+
+    @Column(nullable = false)
+    private Long count = 0L;
+
+    @Builder
+    public ProductViewCount(Product product, Long count) {
+        this.product = product;
+        this.count = 0L;
+    }
+
+    public void incrementCount() {
+        this.count += 1;
+    }
+}

--- a/FreeMarket/src/main/java/com/freemarket/freemarket/product/domain/ProductViewCountRepository.java
+++ b/FreeMarket/src/main/java/com/freemarket/freemarket/product/domain/ProductViewCountRepository.java
@@ -1,0 +1,9 @@
+package com.freemarket.freemarket.product.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ProductViewCountRepository extends JpaRepository<ProductViewCount, Long> {
+    Optional<ProductViewCount> findByProductId(Long productId);
+}

--- a/FreeMarket/src/main/java/com/freemarket/freemarket/product/domain/ProductWishlist.java
+++ b/FreeMarket/src/main/java/com/freemarket/freemarket/product/domain/ProductWishlist.java
@@ -1,0 +1,37 @@
+package com.freemarket.freemarket.product.domain;
+
+import com.freemarket.freemarket.global.auditing.BaseTimeEntity;
+import com.freemarket.freemarket.user.domain.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "product_wishlists" ,uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"user_id", "product_id"})
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductWishlist extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "wishlist_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+    @Builder
+    public ProductWishlist(User user, Product product) {
+        this.user = user;
+        this.product = product;
+    }
+}

--- a/FreeMarket/src/main/java/com/freemarket/freemarket/product/domain/ProductWishlistRepository.java
+++ b/FreeMarket/src/main/java/com/freemarket/freemarket/product/domain/ProductWishlistRepository.java
@@ -1,0 +1,14 @@
+package com.freemarket.freemarket.product.domain;
+
+import com.freemarket.freemarket.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ProductWishlistRepository extends JpaRepository<ProductWishlist, Long>, ProductWishlistRepositoryCustom {
+    Optional<ProductWishlist> findByUserAndProduct(User user, Product product);
+    List<ProductWishlist> findAllByUser(User user);
+    boolean existsByUserAndProduct(User user, Product product);
+    void deleteByUserAndProduct(User user, Product product);
+}

--- a/FreeMarket/src/main/java/com/freemarket/freemarket/product/domain/ProductWishlistRepositoryCustom.java
+++ b/FreeMarket/src/main/java/com/freemarket/freemarket/product/domain/ProductWishlistRepositoryCustom.java
@@ -1,0 +1,5 @@
+package com.freemarket.freemarket.product.domain;
+
+public interface ProductWishlistRepositoryCustom {
+    Long countByProductId(Long productId);
+}

--- a/FreeMarket/src/main/java/com/freemarket/freemarket/product/domain/ProductWishlistRepositoryImpl.java
+++ b/FreeMarket/src/main/java/com/freemarket/freemarket/product/domain/ProductWishlistRepositoryImpl.java
@@ -1,0 +1,21 @@
+package com.freemarket.freemarket.product.domain;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import static com.freemarket.freemarket.product.domain.QProductWishlist.productWishlist;
+
+@RequiredArgsConstructor
+public class ProductWishlistRepositoryImpl implements ProductWishlistRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Long countByProductId(Long productId) {
+        return queryFactory
+                .select(productWishlist.count())
+                .from(productWishlist)
+                .where(productWishlist.product.id.eq(productId))
+                .fetchOne();
+    }
+}


### PR DESCRIPTION
현재 프로젝트에 상품 상세 조회 시 조회수를 집계하고, 사용자가 상품을 관심 목록(찜)에 추가하거나 관리할 수 있는 기능이 필요하다. 또한, 상품 목록이나 상세 정보를 조회할 때 관련 통계 정보(조회수, 관심 등록 수, 현재 사용자의 관심 등록 여부)를 효율적으로 함께 제공해야 한다.


- 상품 조회수 집계: 상품별 조회수를 효율적으로 추적한다.
- 관심 상품(찜) 기능: 사용자가 상품을 찜 목록에 추가/삭제할 수 있도록 한다.
- 통계 정보 연동 조회: 상품 정보 조회 시 N+1 문제 없이 조회수, 찜 수, 찜 여부 통계를 함께 반환하도록 조회 로직을 개선한다.

## 주요 변경 사항
- 상품 조회수 (ProductViewCount):
  - 별도 `ProductViewCount` 엔티티를 추가하여 상품별 조회수를 관리한다. (`Product`와 1:1, 락 경합 감소 목적).
  - `ProductViewService`에서 조회수 증가 및 조회를 처리한다.

- 관심 상품 (ProductWishlist):
  - `ProductWishlist` 엔티티를 추가하여 사용자와 상품 간의 찜 관계(M:N)를 관리한다. (사용자별 상품 중복 찜 방지 제약 포함).
  - `ProductWishlistService`에서 찜 토글, 목록 조회, 상품별 찜 수 조회를 처리한다. (찜 수는 `QueryDSL` 카운트 쿼리 활용)

- 상품 조회 로직 개선 (통계 연동):
  - 상품 목록/상세 조회 시 `N+1` 문제를 피하면서 조회수, 찜 수, 사용자 찜 여부 통계를 효율적으로 가져오도록 `QueryDSL` 기반 조회 로직을 개선한다. (ID 기반 페이징 및 통계 정보 일괄 조회 방식 사용)
 
-DTO 및 Controller 변경:
  - 상품 조회 응답 DTO(`ProductDetailResponse`)에 통계 정보를 포함하도록 수정한다.
  - 찜 관련 API를 위한 `ProductWishlistController`를 추가하고, 기존 `ProductController`의 상품 조회 응답을 업데이트한다.

## 기대 효과
- 조회수 업데이트 시 Product 테이블 락 경합 감소로 인한 성능 향상
- 상품 목록/상세 조회 시 N+1 문제 없이 관련 통계 정보(조회수, 찜 수, 찜 여부) 효율적 조회
- 사용자 경험 향상 (관심 상품 기능 제공 및 통계 정보 확인 가능)
- 관련 로직 분리(View Count, Wishlist)로 코드 명확성 및 유지보수성 증대