### PR TITLE
Refactor: ProductService 분리 #47

### DIFF
--- a/FreeMarket/src/main/java/com/freemarket/freemarket/product/api/ProductController.java
+++ b/FreeMarket/src/main/java/com/freemarket/freemarket/product/api/ProductController.java
@@ -3,7 +3,9 @@ package com.freemarket.freemarket.product.api;
 import com.freemarket.freemarket.global.common.ResponseDTO;
 import com.freemarket.freemarket.global.security.CustomUserDetails;
 import com.freemarket.freemarket.product.api.dto.ProductDto;
-import com.freemarket.freemarket.product.application.ProductService;
+import com.freemarket.freemarket.product.application.ProductManagementService;
+import com.freemarket.freemarket.product.application.ProductQueryService;
+import com.freemarket.freemarket.product.application.ProductStatusService;
 import com.freemarket.freemarket.product.application.ProductViewService;
 import com.freemarket.freemarket.product.domain.ProductCategory;
 import com.freemarket.freemarket.product.domain.ProductStatus;
@@ -37,7 +39,9 @@ import java.util.List;
 @Tag(name = "상품", description = "상품 관련 API")
 public class ProductController {
 
-    private final ProductService productService;
+    private final ProductManagementService productManagementService;
+    private final ProductStatusService productStatusService;
+    private final ProductQueryService productQueryService;
     private final ProductViewService viewService;
 
     @Operation(summary = "상품 등록", description = "새로운 상품을 등록합니다. 상품명, 가격, 수량, 카테고리는 필수 입력 항목입니다.")
@@ -57,13 +61,11 @@ public class ProductController {
             @Valid @RequestPart("request") ProductDto.CreateRequest request,
             @Parameter(description = "이미지 파일") @RequestPart(value = "images", required = false)List<MultipartFile> images) throws BadRequestException {
 
-
         log.info("상품 등록 요청: 사용자 ID {}", userDetails.getUserId());
-        ProductDto.ProductBaseResponse response = productService.createProduct(userDetails.getUserId(), request, images);
+        ProductDto.ProductBaseResponse response = productManagementService.createProduct(userDetails.getUserId(), request, images);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(ResponseDTO.success(response, "상품이 성공적으로 등록되었습니다."));
     }
-
 
     @Operation(summary = "상품 수정", description = "상품 ID로 기존 상품 정보를 수정합니다. 본인이 등록한 상품만 수정 가능합니다.")
     @ApiResponses(value = {
@@ -81,10 +83,10 @@ public class ProductController {
             @Valid @RequestPart("request") ProductDto.UpdateRequest request,
             @Parameter(description = "추가/교체할 이미지") @RequestPart(value = "newImages", required = false) List<MultipartFile> newImages,
             @Parameter(description = "삭제할 이미지 ID") @RequestParam(value = "deleteImageIds", required = false) List<Long> deleteImageIds
-            ) {
+    ) {
 
         log.info("상품 수정 요청: 상품 ID {}, 사용자 ID {}", productId, userDetails.getUserId());
-        ProductDto.ProductBaseResponse response = productService.updateProduct(userDetails.getUserId(), productId, request, newImages, deleteImageIds);
+        ProductDto.ProductBaseResponse response = productManagementService.updateProduct(userDetails.getUserId(), productId, request, newImages, deleteImageIds);
 
         return ResponseEntity.ok(ResponseDTO.success(response, "상품이 성공적으로 수정되었습니다."));
     }
@@ -96,13 +98,13 @@ public class ProductController {
     })
     @GetMapping("/{productId}")
     public ResponseEntity<ResponseDTO<ProductDto.ProductDetailResponse>> getProduct(
-        @Parameter(description = "상품 ID", required = true) @PathVariable Long productId,
-        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+            @Parameter(description = "상품 ID", required = true) @PathVariable Long productId,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
 
         // 조회수 증가
         viewService.incrementViewCount(productId);
         log.info("상품 조회 요청: 상품 ID {}", productId);
-        ProductDto.ProductDetailResponse response = productService.getProduct(productId, userDetails.getUserId());
+        ProductDto.ProductDetailResponse response = productQueryService.getProduct(productId, userDetails.getUserId());
 
         return ResponseEntity.ok(ResponseDTO.success(response));
     }
@@ -125,7 +127,7 @@ public class ProductController {
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
 
         log.info("상품 목록 조회 요청: 키워드 {}, 상태 {}", keyword, status);
-        Page<ProductDto.ProductDetailResponse> response = productService.getProducts(keyword, status, pageable, userDetails.getUserId());
+        Page<ProductDto.ProductDetailResponse> response = productQueryService.getProducts(keyword, status, pageable, userDetails.getUserId());
 
         return ResponseEntity.ok(ResponseDTO.success(response));
     }
@@ -152,7 +154,7 @@ public class ProductController {
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
 
         log.info("카테고리별 상품 조회 요청: 카테고리 {}, 키워드 {}, 상태 {}", category, keyword, status);
-        Page<ProductDto.ProductDetailResponse> response = productService.getProductsByCategory(category, keyword, status, pageable, userDetails.getUserId());
+        Page<ProductDto.ProductDetailResponse> response = productQueryService.getProductsByCategory(category, keyword, status, pageable, userDetails.getUserId());
 
         return ResponseEntity.ok(ResponseDTO.success(response));
     }
@@ -170,7 +172,7 @@ public class ProductController {
             @Parameter(description = "삭제할 상품 ID", required = true) @PathVariable Long productId) {
 
         log.info("상품 삭제 요청: 상품 ID {}, 사용자 ID {}", productId, userDetails.getUserId());
-        productService.deleteProduct(userDetails.getUserId(), productId);
+        productManagementService.deleteProduct(userDetails.getUserId(), productId);
 
         return ResponseEntity.ok(ResponseDTO.success(null, "상품이 성공적으로 삭제되었습니다."));
     }
@@ -192,7 +194,7 @@ public class ProductController {
         log.info("상품 판매완료 처리 요청: 상품 ID {}, 판매자 ID {}, 구매자 ID {}",
                 productId, userDetails.getUserId(), buyerId);
 
-        ProductDto.ProductBaseResponse response = productService.markProductAsSold(
+        ProductDto.ProductBaseResponse response = productStatusService.markProductAsSold(
                 userDetails.getUserId(), productId, buyerId);
 
         return ResponseEntity.ok(ResponseDTO.success(response, "상품이 판매완료 처리되었습니다."));
@@ -213,10 +215,9 @@ public class ProductController {
 
         log.info("판매완료 취소 요청: 상품 ID {}, 판매자 ID {}", productId, userDetails.getUserId());
 
-        ProductDto.ProductBaseResponse response = productService.cancelProductSold(
+        ProductDto.ProductBaseResponse response = productStatusService.cancelProductSold(
                 userDetails.getUserId(), productId);
 
         return ResponseEntity.ok(ResponseDTO.success(response, "판매완료가 취소되었습니다."));
     }
-
 }

--- a/FreeMarket/src/main/java/com/freemarket/freemarket/product/application/ProductManagementService.java
+++ b/FreeMarket/src/main/java/com/freemarket/freemarket/product/application/ProductManagementService.java
@@ -3,7 +3,6 @@ package com.freemarket.freemarket.product.application;
 import com.freemarket.freemarket.global.email.exception.EmailVerificationException;
 import com.freemarket.freemarket.global.file.application.FileStorageService;
 import com.freemarket.freemarket.product.api.dto.ProductDto;
-import com.freemarket.freemarket.product.api.dto.ProductWithStatsDto;
 import com.freemarket.freemarket.product.domain.*;
 import com.freemarket.freemarket.product.exception.ProductException;
 import com.freemarket.freemarket.user.domain.User;
@@ -12,8 +11,6 @@ import com.freemarket.freemarket.user.exception.UserException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.coyote.BadRequestException;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -25,19 +22,15 @@ import java.util.List;
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
-public class ProductService {
-
+public class ProductManagementService {
     private final ProductRepository productRepository;
     private final UserRepository userRepository;
     private final FileStorageService fileStorageService;
-    private final ProductViewService viewService;
-    private final ProductWishlistService wishlistService;
 
     // 상품 등록
     @Transactional
     public ProductDto.ProductBaseResponse createProduct(Long userId, ProductDto.CreateRequest request, List<MultipartFile> images) throws BadRequestException {
-        User seller = userRepository.findById(userId)
-                .orElseThrow(() -> new UserException.UserNotFoundException(userId));
+        User seller = getUser(userId);
 
         // 학교 이메일 인증 여부 확인
         emailVerification(seller);
@@ -83,9 +76,10 @@ public class ProductService {
     }
 
     // 상품 수정
+
     @Transactional
     public ProductDto.ProductBaseResponse updateProduct(Long userId, Long productId, ProductDto.UpdateRequest request,
-                                                    List<MultipartFile> newImages, List<Long> deleteImageIds) {
+                                                        List<MultipartFile> newImages, List<Long> deleteImageIds) {
         Product product = getProductWithSellerCheck(productId, userId);
         product.update(request.name(), request.description(), request.price(), request.stock(), request.category());
         if (request.status() != null) product.changeStatus(request.status());
@@ -140,78 +134,19 @@ public class ProductService {
             throw new ProductException.ProductUpdateException(e.getMessage());
         }
     }
-
-    // 상품 단건 조회
-    public ProductDto.ProductDetailResponse getProduct(Long productId, Long userId) {
-        Product product = findProduct(productId);
-
-        // 조회수
-        Long viewCount = viewService.getViewCount(productId);
-        // 관심 등록 수
-        Long wishlistCount = wishlistService.getWishlistCount(productId);
-
-        // 현재 사용자의 관심 등록 여부
-        boolean isWishlisted = userId != null ? wishlistService.isWishlisted(userId, productId) : false;
-        return ProductDto.ProductDetailResponse.from(product, viewCount, wishlistCount, isWishlisted);
-    }
-
-    // 상품 목록 조회
-    public Page<ProductDto.ProductDetailResponse> getProducts(String keyword, ProductStatus status, Pageable pageable, Long userId) {
-        return productRepository.findAllWithStatsAndWishlist(keyword, status, pageable, userId)
-                .map(ProductWithStatsDto::toProductDetailResponse);
-    }
-
-    // 카테고리별 상품 조회
-    public Page<ProductDto.ProductDetailResponse> getProductsByCategory(ProductCategory category, String keyword, ProductStatus status,
-                                                                  Pageable pageable, Long userId) {
-        return productRepository.findByCategoryWithStatsAndWishlist(category, keyword, status, pageable, userId)
-                .map(ProductWithStatsDto::toProductDetailResponse);
-    }
-
     // 상품 삭제
+
     @Transactional
     public void deleteProduct(Long userId, Long productId) {
         Product product = getProductWithSellerCheck(productId, userId);
         productRepository.delete(product);
         log.info("상품 삭제 완료: 상품 ID {}, 판매자 ID {}", productId, userId);
     }
-
-    // 판매 완료 처리
-    @Transactional
-    public ProductDto.ProductBaseResponse markProductAsSold(Long sellerId, Long productId, Long buyerId) {
-        Product product = getProductWithSellerCheck(productId, sellerId);
-
-        if (product.getStatus() == ProductStatus.SOLD_OUT) {
-            throw new ProductException.AlreadySoldProductException();
-        }
-
-        User buyer = userRepository.findById(buyerId)
-                .orElseThrow(() -> new UserException.UserNotFoundException(buyerId));
-
-        product.markAsSold(buyer);
-
-        log.info("상품 판매완료 처리: 상품 ID {}, 판매자 ID {}, 구매자 ID {}", productId, sellerId, buyerId);
-
-        return ProductDto.ProductBaseResponse.from(product);
-    }
-
-    // 판매완료 취소 처리 메서드
-    @Transactional
-    public ProductDto.ProductBaseResponse cancelProductSold(Long sellerId, Long productId) {
-        Product product = getProductWithSellerCheck(productId, sellerId);
-
-        if (product.getStatus() != ProductStatus.SOLD_OUT) {
-            throw new ProductException.NotSoldProductException();
-        }
-
-        product.cancelSold();
-        log.info("판매완료 취소 처리: 상품 ID {}, 판매자 ID {}", productId, sellerId);
-        return ProductDto.ProductBaseResponse.from(product);
-    }
-
     // 판매자 권한 확인 후 상품 조회
-    private Product getProductWithSellerCheck(Long productId, Long userId) {
-        Product product = findProduct(productId);
+
+    Product getProductWithSellerCheck(Long productId, Long userId) {
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new ProductException.ProductNotFoundException(productId));
 
         if (!product.getSeller().getId().equals(userId)) {
             throw new ProductException.ProductAccessDeniedException();
@@ -219,17 +154,14 @@ public class ProductService {
 
         return product;
     }
-    
-    private Product findProduct(Long productId) {
-        Product product = productRepository.findById(productId)
-                .orElseThrow(() -> new ProductException.ProductNotFoundException(productId));
-        return product;
-    }
-
     private static void emailVerification(User seller) {
         if (!seller.isEmailVerified()) {
             throw new EmailVerificationException.EmailNotVerifiedException();
         }
     }
 
+    private User getUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new UserException.UserNotFoundException(userId));
+    }
 }

--- a/FreeMarket/src/main/java/com/freemarket/freemarket/product/application/ProductQueryService.java
+++ b/FreeMarket/src/main/java/com/freemarket/freemarket/product/application/ProductQueryService.java
@@ -1,0 +1,58 @@
+package com.freemarket.freemarket.product.application;
+
+import com.freemarket.freemarket.product.api.dto.ProductDto;
+import com.freemarket.freemarket.product.api.dto.ProductWithStatsDto;
+import com.freemarket.freemarket.product.domain.Product;
+import com.freemarket.freemarket.product.domain.ProductCategory;
+import com.freemarket.freemarket.product.domain.ProductRepository;
+import com.freemarket.freemarket.product.domain.ProductStatus;
+import com.freemarket.freemarket.product.exception.ProductException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ProductQueryService {
+
+    private final ProductRepository productRepository;
+    private final ProductViewService viewService;
+    private final ProductWishlistService wishlistService;
+
+    // 상품 단건 조회
+    public ProductDto.ProductDetailResponse getProduct(Long productId, Long userId) {
+        Product product = findProduct(productId);
+
+        // 조회수
+        Long viewCount = viewService.getViewCount(productId);
+        // 관심 등록 수
+        Long wishlistCount = wishlistService.getWishlistCount(productId);
+
+        // 현재 사용자의 관심 등록 여부
+        boolean isWishlisted = userId != null ? wishlistService.isWishlisted(userId, productId) : false;
+        return ProductDto.ProductDetailResponse.from(product, viewCount, wishlistCount, isWishlisted);
+    }
+
+    // 상품 목록 조회
+    public Page<ProductDto.ProductDetailResponse> getProducts(String keyword, ProductStatus status, Pageable pageable, Long userId) {
+        return productRepository.findAllWithStatsAndWishlist(keyword, status, pageable, userId)
+                .map(ProductWithStatsDto::toProductDetailResponse);
+    }
+
+    // 카테고리별 상품 조회
+    public Page<ProductDto.ProductDetailResponse> getProductsByCategory(ProductCategory category, String keyword, ProductStatus status,
+                                                                        Pageable pageable, Long userId) {
+        return productRepository.findByCategoryWithStatsAndWishlist(category, keyword, status, pageable, userId)
+                .map(ProductWithStatsDto::toProductDetailResponse);
+    }
+
+    private Product findProduct(Long productId) {
+        return productRepository.findById(productId)
+                .orElseThrow(() -> new ProductException.ProductNotFoundException(productId));
+    }
+}

--- a/FreeMarket/src/main/java/com/freemarket/freemarket/product/application/ProductStatusService.java
+++ b/FreeMarket/src/main/java/com/freemarket/freemarket/product/application/ProductStatusService.java
@@ -1,0 +1,56 @@
+package com.freemarket.freemarket.product.application;
+
+import com.freemarket.freemarket.product.api.dto.ProductDto;
+import com.freemarket.freemarket.product.domain.Product;
+import com.freemarket.freemarket.product.domain.ProductStatus;
+import com.freemarket.freemarket.product.exception.ProductException;
+import com.freemarket.freemarket.user.domain.User;
+import com.freemarket.freemarket.user.domain.UserRepository;
+import com.freemarket.freemarket.user.exception.UserException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ProductStatusService {
+
+    private final ProductManagementService productManagementService;
+    private final UserRepository userRepository;
+
+    // 판매 완료 처리
+    @Transactional
+    public ProductDto.ProductBaseResponse markProductAsSold(Long sellerId, Long productId, Long buyerId) {
+        Product product = productManagementService.getProductWithSellerCheck(productId, sellerId);
+
+        if (product.getStatus() == ProductStatus.SOLD_OUT) {
+            throw new ProductException.AlreadySoldProductException();
+        }
+
+        User buyer = userRepository.findById(buyerId)
+                .orElseThrow(() -> new UserException.UserNotFoundException(buyerId));
+
+        product.markAsSold(buyer);
+
+        log.info("상품 판매완료 처리: 상품 ID {}, 판매자 ID {}, 구매자 ID {}", productId, sellerId, buyerId);
+
+        return ProductDto.ProductBaseResponse.from(product);
+    }
+
+    // 판매완료 취소 처리 메서드
+    @Transactional
+    public ProductDto.ProductBaseResponse cancelProductSold(Long sellerId, Long productId) {
+        Product product = productManagementService.getProductWithSellerCheck(productId, sellerId);
+
+        if (product.getStatus() != ProductStatus.SOLD_OUT) {
+            throw new ProductException.NotSoldProductException();
+        }
+
+        product.cancelSold();
+        log.info("판매완료 취소 처리: 상품 ID {}, 판매자 ID {}", productId, sellerId);
+        return ProductDto.ProductBaseResponse.from(product);
+    }
+}


### PR DESCRIPTION
현재 `ProductService` 클래스는 상품 관리(CRUD 작업), 상품 상태 관리, 상품 조회 등 여러 책임을 담당하고 있다. 이는 단일 책임 원칙(`SRP`)을 위반하며, 클래스를 유지보수하고 확장하기 어렵게 만든다.

## 현재 구현의 문제점
- ProductService가 너무 큼(약 300줄)과 동시에 다양한 책임을 가짐
- 서로 다른 관심사의 메서드들이 혼재되어 있음
- 한 측면(예: 상품 조회)을 변경하려면 관련 없는 책임도 함께 처리하는 클래스를 수정해야 함

## 솔루션
`ProductService`를 명확하고 집중된 책임을 가진 세 개의 서비스 클래스로 리팩토링:

### ProductManagementService
- CRUD 작업(상품 생성, 수정, 삭제) 담당
- 파일 업로드 및 이미지 관리 처리
- 상품 메타데이터 관리

### ProductStatusService
- 상품 상태 전환(판매 완료 표시, 판매 취소) 관리
- 구매자 할당 처리
- 상품 라이프사이클 로직 포함

### ProductQueryService
- 모든 상품 조회 및 검색 처리
- 상품 통계(조회수, 찜 수) 통합
- 페이지네이션 및 필터링 관리

## 이점
- 코드 구성 및 가독성 향상
- SOLID 원칙 준수 강화
- 각 특정 기능을 더 쉽게 유지보수 및 확장 가능
- 더 명확한 의존성
- 더 집중된 테스트 가능